### PR TITLE
Execution after NaN

### DIFF
--- a/src/Handlers.cpp.Rt
+++ b/src/Handlers.cpp.Rt
@@ -890,12 +890,14 @@ class cbAveraging: public Callback{
 
 class cbFailcheck: public Callback {
 	lbRegion reg;
+	int rkept;
 	public:
 	int Init() {
 		Callback::Init();
 		reg.dx = solver->region.dx;
 		reg.dy = solver->region.dy;
 		reg.dz = solver->region.dz;
+		rkept = 1;
 		return 0;
 	}
 	int DoIt() {
@@ -916,10 +918,15 @@ class cbFailcheck: public Callback {
 		}
 		<?R }; ifdef(); ?>
 		MPI_Allreduce(&cond,&fin,1,MPI_INT,MPI_LOR,MPI_COMM_WORLD);
-		if (fin) { 
-			 notice("Stopping due to Nan value\n");
-			 ret = ITERATION_STOP;
-		}
+	        if ((fin) && (rkept)) {
+                         rkept = 0;
+                         for (pugi::xml_node par = node.first_child(); par; par = par.next_sibling()) {
+                         	Handler hand(par, solver);
+                                if (hand) hand.DoIt();
+                         }
+                         notice("Stopping due to Nan value\n");
+                         ret = ITERATION_STOP;
+                }
 		return ret;
 	}	
 	int Finish() {

--- a/src/Handlers.cpp.Rt
+++ b/src/Handlers.cpp.Rt
@@ -920,6 +920,7 @@ class cbFailcheck: public Callback {
 		MPI_Allreduce(&cond,&fin,1,MPI_INT,MPI_LOR,MPI_COMM_WORLD);
 	        if ((fin) && (rkept)) {
                          rkept = 0;
+			 notice("NaN value discovered. Executing final actions from the Failcheck element before full stop...\n");
                          for (pugi::xml_node par = node.first_child(); par; par = par.next_sibling()) {
                          	Handler hand(par, solver);
                                 if (hand) hand.DoIt();


### PR DESCRIPTION
I implemented, what was proposed in issue #49 . Now post-Failcheck action can be performed, such as basic VTK or even something like this:
```xml
<Failcheck Iterations="1000">
         <Solve Iterations="2000">
               <VTK name="withnan" Iterations="500"/>
         </Solve>
</Failcheck>
```
