### PR TITLE
Adding support for "drawing" mode in Geometry

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,6 +14,8 @@ We are really glad that you would like to contribute to TCLB. We would appreciat
 - [ ] You did a clever trick? Please leave a suitable comment
 - [ ] Please don't brake naming convention (at least look at surrounding code)
 - [ ] Try too use meaningful variable names
+- [ ]  Do not pull/merge XXX_new's.  Its either something different and should have different name or it is an replacement of XXX (in whole code)
+
 
 ### Compilation
 The code will be tested automaticly with Travis-CI, but before that, you can test your code on your machine

--- a/src/Geometry.cpp.Rt
+++ b/src/Geometry.cpp.Rt
@@ -122,6 +122,7 @@ int Geometry::setFlag(const pugi::char_t * name)
     }
     fg = node.attribute("value").as_int();
     E(setMask(node.attribute("mask").value()));
+    fg_mode = MODE_OVERWRITE;
     return 0;
 }
 
@@ -141,6 +142,26 @@ int Geometry::setMask(const pugi::char_t * name)
     }
     fg_mask = node.attribute("value").as_int(-1);
     return 0;
+}
+
+/// Set the forground flag mode
+/**
+        Set the foreground flag mode, by which the forground flag will be set
+        \param name Name of the flag mask/NodeType to set
+*/
+int Geometry::setMode(const pugi::char_t * mode)
+{
+	if (strcmp(mode, "overwrite") == 0) {
+		fg_mode = MODE_OVERWRITE;
+	} else if (strcmp(mode, "fill") == 0) {
+		fg_mode = MODE_FILL;
+	} else if (strcmp(mode, "change") == 0) {
+		fg_mode = MODE_CHANGE;
+	} else {
+		error("Unknown mode (in xml): %s\n", mode);
+		return -1;
+	}
+	return 0;
 }
 
 int Geometry::setZone(const pugi::char_t * name)
@@ -720,6 +741,8 @@ int Geometry::load(pugi::xml_node & node)
 	        E(setZone(attr.value()));
 	    } else if (strcmp(attr.name(), "mask") == 0) {
 	        E(setMask(attr.value()));
+	    } else if (strcmp(attr.name(), "mode") == 0) {
+	        E(setMode(attr.value()));
 	    } else {
 	        
 	    }

--- a/src/Geometry.cpp.Rt
+++ b/src/Geometry.cpp.Rt
@@ -282,6 +282,11 @@ inline flag_t Geometry::Dot(int x, int y, int z)
 {
     if (region.isIn(x, y, z)) {
 	int i = region.offset(x, y, z);
+	if (geom[i] & fg_mask) {
+		if (fg_mode == MODE_FILL) return NODE_None;
+	} else {
+		if (fg_mode == MODE_CHANGE) return NODE_None;
+	}
 	return geom[i] = (geom[i] & (~fg_mask)) | fg;
     } else 
     return NODE_None;

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -16,6 +16,12 @@
         short int v;
 };
 
+enum draw_mode {
+  MODE_OVERWRITE,
+  MODE_FILL,
+  MODE_CHANGE
+};
+
 /// Class responsible for constructing the table of flags/NodeTypes
 class Geometry {
 public:
@@ -30,11 +36,11 @@ public:
 private:
   flag_t fg; ///< Foreground flag used for filling
   flag_t fg_mask; ///< Foreground flag mask used for filling
-  flag_t fg_over;
-  flag_t fg_under;
+  draw_mode fg_mode; ///< Foreground flag drawing mode
   pugi::xml_node fg_xml; ///< Foreground flag XML element
   int setFlag(const pugi::char_t * name);
   int setMask(const pugi::char_t * name);
+  int setMode(const pugi::char_t * mode);
   int setZone(const pugi::char_t * name);
   int Draw(pugi::xml_node&);
   int loadZone(const char * name);

--- a/src/Handlers.cpp.Rt
+++ b/src/Handlers.cpp.Rt
@@ -1832,8 +1832,8 @@ class conControl: public Action {
                         }
                         int k = 0;
                         int max_k = csv_data[ "_time" ].size() - 2;
-                        if (max_k < 1) {
-                                error("Not enough records in CSV file or something went terribly wrong\n");
+                        if (max_k < 0) {
+                                error("Not enaugh records in CSV file or something went terribly wrong\n");
                                 return -1;
                         }
                                 

--- a/src/Handlers.cpp.Rt
+++ b/src/Handlers.cpp.Rt
@@ -1833,7 +1833,7 @@ class conControl: public Action {
                         int k = 0;
                         int max_k = csv_data[ "_time" ].size() - 2;
                         if (max_k < 1) {
-                                error("Not enaugh records in CSV file or something went terribly wrong\n");
+                                error("Not enough records in CSV file or something went terribly wrong\n");
                                 return -1;
                         }
                                 

--- a/src/d3q19_heat/Dynamics.R
+++ b/src/d3q19_heat/Dynamics.R
@@ -29,4 +29,4 @@ AddSetting(name="Pressure", default="0Pa", comment='inlet pressure', zonal=TRUE)
 AddSetting(name="Temperature", default=1, comment='inlet density', zonal=TRUE)
 AddSetting(name="FluidAlpha", default=1, comment='inlet density')
 
-AddNodeType("ADDITIONALS","Heater")
+AddNodeType("Heater","ADDITIONALS")

--- a/src/lib/boundary.R
+++ b/src/lib/boundary.R
@@ -40,6 +40,21 @@ FullSymmetryZ = function() {
 	FullBounceOp(function(X) {X[3]=-X[3]; X});
 }
 
+SymmetryNew  = function(direction,sign) {
+        by(Density, Density$group, function(D) {
+                i = c("dx","dy","dz")
+                D1 = D[,c("name",i)]
+                D2 = D1
+                D2[,direction + 1] = -D2[,direction + 1]
+                D3 = merge(D1,D2,by=i)
+                D3$name.x < D3$name.y
+                D3 = D3[D3$name.x < D3$name.y,]
+                for ( i in seq_len(nrow(D3))) {
+                        if (sign > 0) C( PV(D3$name.x[i]), PV(D3$name.y[i]) )
+                        else C( PV(D3$name.y[i]), PV(D3$name.x[i]) )
+                }
+        })
+}
 
 C_pull = function(W, var) {
 	ret = div.mod(W[[1]],var)
@@ -166,7 +181,7 @@ ZouHeRewrite = function(EQ, f, n, type=c("velocity","pressure","do nothing"), rh
 		eqn = V( fs %*% EQ2$U %*% diag(d))
 		rhs = rhs * abs(n) * sum(fs)
 	} else stop("Unknown type in ZouHe")
-	cat("/********* ", type, "-type Zue He boundary condition  ****************/\n",sep="");
+	cat("/********* ", type, "-type Zou He boundary condition  ****************/\n",sep="");
 	eqn = eqn - rhs;
 	if (length(eqn) != length(R)) stop("Something is terribly wrong")
   # --- Solving all equations for 'R'


### PR DESCRIPTION
I added the feature in the Geometry module, that allows to specify if a node should be:
- `mode="overwrite"` -- Overwrites the previous value of the node type
- `mode="change"` -- Overwrites only non-zero node types.
- `mode="fill"` -- Sets the node type only in elements that didn't have the node type earlier (had 0 in this `mask`)

Example:
```xml
<EVelocity mode="fill">
```
will set the EVelocity boundary condition only on elements that don't have previously set boundary condition.

@mdzik @shkodm 