### PR TITLE
Update Dynamics.R

### DIFF
--- a/src/d3q27_cumulant/Dynamics.R
+++ b/src/d3q27_cumulant/Dynamics.R
@@ -21,7 +21,7 @@ AddSetting(name="Velocity", default="0m/s", comment='Inlet velocity', zonal=TRUE
 AddSetting(name="Pressure", default="0Pa", comment='Inlet pressure', zonal=TRUE)
 AddSetting(name="Turbulence", comment='Turbulence intensity', zonal=TRUE)
 
-AddSetting(name="GalileanCorrection",default=0.,comment='Galilean correction term')
+AddSetting(name="GalileanCorrection",default=1.,comment='Galilean correction term')
 AddSetting(name="ForceX",default=0, comment='Force force X')
 AddSetting(name="ForceY",default=0,comment='Force force Y')
 AddSetting(name="ForceZ",default=0,comment='Force force Z')


### PR DESCRIPTION
I changed Galilean correction default setting to 1(enabled), thus no need to specify it in `<Params/>` anymore. I believe, it was like that, since until fixed in #15, default settings were not working (were just setting to zero). 