### PR TITLE
[V6.1 RC] Corrected the Get_ Set_ functions

### DIFF
--- a/models/flow/d2q9/Dynamics.R
+++ b/models/flow/d2q9/Dynamics.R
@@ -20,8 +20,8 @@ AddDensity( name="f[8]", dx= 1, dy=-1, group="f")
 # If present thei are used:
 # As VelocityX/Y for Boundary conditions
 # As mass force (+ GravitationX/Y) in fluid
-AddDensity( name="BC[0]", dx=0, dy=0, group="BC")
-AddDensity( name="BC[1]", dx=0, dy=0, group="BC")
+AddDensity( name="BC[0]", group="BC", parameter=TRUE)
+AddDensity( name="BC[1]", group="BC", parameter=TRUE)
 
 
 # Quantities - table of fields that can be exported from the LB lattice (like density, velocity etc)

--- a/models/multiphase/d2q9_pf/Dynamics.R
+++ b/models/multiphase/d2q9_pf/Dynamics.R
@@ -50,8 +50,8 @@ AddSetting(name="OverwriteVelocityField", default="0")
 # As VelocityX/Y for Boundary conditions
 # As mass force (+ GravitationX/Y) in fluid
 # If OverwriteVelocityField==1, this will be used to overwrite velocity
-AddDensity( name="BC[0]", dx=0, dy=0, group="BC")
-AddDensity( name="BC[1]", dx=0, dy=0, group="BC")
+AddDensity( name="BC[0]", group="BC", parameter=TRUE)
+AddDensity( name="BC[1]", group="BC", parameter=TRUE)
 
 
 

--- a/src/Lattice.cu.Rt
+++ b/src/Lattice.cu.Rt
@@ -940,7 +940,8 @@ void Lattice::GetFlags(lbRegion over, flag_t * NodeType)
 }
 
 <?R
-	for (d in rows(rbind(Density,DensityAD))) { 
+	for (f in Fields[Fields$parameter]) { 
+
 	for (adjoint in c(TRUE,FALSE)) {
 	if (adjoint) {
 		from="aSnaps[aSnap]";
@@ -952,47 +953,47 @@ void Lattice::GetFlags(lbRegion over, flag_t * NodeType)
 	ifdef(adjoint)
 ?>
 
-/// Get [<?%s d$comment ?>]
+/// Get [<?%s f$comment ?>]
 /**
-        Retrive the values of the density <?%s d$nicename ?> (<?%s d$comment ?>)
+        Retrive the values of the density <?%s f$nicename ?> (<?%s f$comment ?>)
         from the GPU memory
 */
-void Lattice::Get_<?%s d$nicename ?><?%s suff ?>(real_t * tab)
+void Lattice::Get_<?%s f$nicename ?><?%s suff ?>(real_t * tab)
 {
-	debug2("Pulling all <?%s d$nicename ?>\n");
+	debug2("Pulling all <?%s f$nicename ?>\n");
 	CudaMemcpy(
 		tab,
-		&<?%s from ?>.block14[<?%s d$Index ?>*region.sizeL()], 
+		&<?%s from ?>.block14[<?%s f$Index ?>*region.sizeL()], 
 		region.sizeL()*sizeof(real_t),
 		cudaMemcpyDeviceToHost);
 }
 
-/// Clear [<?%s d$comment ?>]
+/// Clear [<?%s f$comment ?>]
 /**
         Clear (set to zero) the values of
-        the density <?%s d$nicename ?> (<?%s d$comment ?>)
+        the density <?%s f$nicename ?> (<?%s f$comment ?>)
         in the GPU memory
 */
-void Lattice::Clear_<?%s d$nicename ?><?%s suff ?>()
+void Lattice::Clear_<?%s f$nicename ?><?%s suff ?>()
 {
-	debug2("Clearing all <?%s d$nicename ?>\n");
+	debug2("Clearing all <?%s f$nicename ?>\n");
 	CudaMemset(
-		&<?%s from ?>.block14[<?%s d$Index ?>*region.sizeL()], 
+		&<?%s from ?>.block14[<?%s f$Index ?>*region.sizeL()], 
 		0,
 		region.sizeL()*sizeof(real_t));
 }
 
-/// Set [<?%s d$comment ?>]
+/// Set [<?%s f$comment ?>]
 /**
         Set the values of
-        the density <?%s d$nicename ?> (<?%s d$comment ?>)
+        the density <?%s f$nicename ?> (<?%s f$comment ?>)
         in the GPU memory
 */
-void Lattice::Set_<?%s d$nicename ?><?%s suff ?>(real_t * tab)
+void Lattice::Set_<?%s f$nicename ?><?%s suff ?>(real_t * tab)
 {
-	debug2("Setting all <?%s d$nicename ?>\n");
+	debug2("Setting all <?%s f$nicename ?>\n");
 	CudaMemcpy(
-		&<?%s from ?>.block14[<?%s d$Index?>*region.sizeL()], 
+		&<?%s from ?>.block14[<?%s f$Index?>*region.sizeL()], 
 		tab,
 		region.sizeL()*sizeof(real_t),
 		cudaMemcpyHostToDevice);

--- a/src/Solver.cpp.Rt
+++ b/src/Solver.cpp.Rt
@@ -537,7 +537,7 @@ int Solver::getComponentIntoBuffer(const char* comp, real_t* &buf, long int*  di
     if (!somethingWritten){
         output("Possible densities:\n");
     <?R
-        for (d in rows(DensityAll)) { 
+        for (d in rows(DensityAll)) if (d$parameter){ 
             ?> output("-> <?%s d$name ?>\n") ; <?R
         }
     ?>

--- a/src/Solver.cpp.Rt
+++ b/src/Solver.cpp.Rt
@@ -485,7 +485,7 @@ int Solver::saveComp(const char* filename, const char* comp) {
 	output("Saving component %s to file %s\n", comp, fn);
     bool somethingWritten = false;
 <?R 
-    for (d in rows(DensityAll)) { 
+    for (d in rows(DensityAll)) if (d$parameter) { 
 ?>
 	if (strcmp(comp, "<?%s d$name ?>") == 0) {
         lattice->Get_<?%s d$nicename ?>(buf); 
@@ -525,7 +525,7 @@ int Solver::getComponentIntoBuffer(const char* comp, real_t* &buf, long int*  di
 	output("Providing component %s to buffer..\n", comp);
     bool somethingWritten = false;
 <?R 
-    for (d in rows(DensityAll)) { 
+    for (d in rows(DensityAll)) if (d$parameter){ 
 ?>
 	if (strcmp(comp, "<?%s d$name ?>") == 0) {
         lattice->Get_<?%s d$nicename ?>(buf); 
@@ -603,7 +603,7 @@ ifdef();
 
 int Solver::loadComponentFromBuffer(const char* comp,  real_t* buf) {
 	int n = region.size();
-<?R for (d in rows(DensityAll)) { ?>
+<?R for (d in rows(DensityAll)) if (d$parameter) { ?>
 	if (strcmp(comp, "<?%s d$name ?>") == 0) lattice->Set_<?%s d$nicename ?>(buf); <?R
 } ?>
     delete [] buf;
@@ -629,7 +629,7 @@ int Solver::loadComp(const char* filename, const char* comp) {
 	assert(n == nn);
 	fclose(f);
 //	for (int i=0; i<n;i ++) buf[i]=1.23;
-<?R for (d in rows(DensityAll)) { ?>
+<?R for (d in rows(DensityAll)) if (d$parameter) { ?>
 	if (strcmp(comp, "<?%s d$name ?>") == 0) lattice->Set_<?%s d$nicename ?>(buf); <?R
 } ?>
 

--- a/src/vtkLattice.cpp.Rt
+++ b/src/vtkLattice.cpp.Rt
@@ -57,17 +57,6 @@ int vtkWriteLattice(char * filename, Lattice * lattice, UnitEnv units, name_set 
 	}
 	<?R }; ifdef(); ?>
 
-// ------------------------------ DUMP ALL DENSITIES ----------------------------
-/* 
-	real_t* tmp = new real_t[size];
-	<?R for (d in rows(DensityAll)) { ?>
-	{
-		lattice->Get_<?%s d$nicename ?>(reg, tmp);
-		vtkFile.WriteField("<?%s d$nicename ?>",tmp);
-	}
-	<?R } ?>
-	delete[] tmp;
-*/
 	
 	vtkFile.Finish();
 	vtkFile.Close();


### PR DESCRIPTION
Corrected the Get_ Set_ and Clear_ functions in Lattice.cu, to work **only** with densities marked as `parameter`. This changes the behaviour of PythonCall, as it can now read and write only such densities/fields. You can declare such density as:
```R
AddDensity(name="G", parameter=TRUE)
```
A density which is marked as parameter can only have streaming direction 0 (dx=0,dy=0,dz=0).