### PR TITLE
Modifying the SyntheticTurbulence mechanism

### DIFF
--- a/models/flow/d3q27/Dynamics.c.Rt
+++ b/models/flow/d3q27/Dynamics.c.Rt
@@ -126,7 +126,7 @@ CudaDeviceFunction void SetEquilibrum(real_t rho, real_t Jx, real_t Jy, real_t J
 }
 
 CudaDeviceFunction void Init() {
-	vector_t ST = SyntheticTurbulence(0);
+	vector_t ST = SyntheticTurbulence(X,Y,Z);
 	ST.x = Velocity + Turbulence*ST.x;
 	ST.y = Turbulence*ST.y;
 	ST.z = Turbulence*ST.z;

--- a/models/flow/d3q27_cumulant/Dynamics.c.Rt
+++ b/models/flow/d3q27_cumulant/Dynamics.c.Rt
@@ -196,30 +196,19 @@ CudaDeviceFunction void SetEquilibrum(real_t rho, real_t Jx, real_t Jy, real_t J
 }
 
 CudaDeviceFunction void Init() {
-	vector_t ST = SyntheticTurbulence(0);
-	ST.x = Turbulence*ST.x;
+	vector_t ST = SyntheticTurbulence(X,Y,Z);
+	ST.x = Turbulence*ST.x + Velocity;
 	ST.y = Turbulence*ST.y;
 	ST.z = Turbulence*ST.z; 
-	SynthTX = ST.x;
-	SynthTY = ST.y;
-	SynthTZ = ST.z;
-	ST.x = ST.x + Velocity;	
 	SetEquilibrum(1.0 + Pressure * 3.0, ST.x, ST.y, ST.z);
 }
 
 CudaDeviceFunction void WVelocityTurbulent() {
-        real_t k_aa = exp(-1/constContainer.ST.TimeWN);
-        real_t k_bb =  sqrt(1 - k_aa*k_aa);
-       	vector_t ST = SyntheticTurbulence(0);
-        ST.x = Turbulence*ST.x*k_bb + SynthTX*k_aa;
-        ST.y = Turbulence*ST.y*k_bb + SynthTY*k_aa;
-       	ST.z = Turbulence*ST.z*k_bb + SynthTZ*k_aa; 
-        SynthTX = ST.x;
-        SynthTY = ST.y;
-        SynthTZ = ST.z;
-        ST.x = ST.x + Velocity;
+      	vector_t ST = SyntheticTurbulence(X-Time*Velocity,Y,Z);
+	ST.x = Turbulence*ST.x + Velocity;
+	ST.y = Turbulence*ST.y;
+	ST.z = Turbulence*ST.z; 
 	<?R ZouHe(EQ, 1, 1, "velocity",V=PV("ST.x"),V3=c(PV("ST.x"),PV("ST.y"),PV("ST.z"))) ?> 
-
 }
 
 CudaDeviceFunction void CollisionMRT()

--- a/src/Handlers/acSyntheticTurbulence.cpp
+++ b/src/Handlers/acSyntheticTurbulence.cpp
@@ -103,11 +103,13 @@ int acSyntheticTurbulence::Init () {
 		{
 			double timeWN;			
 			if (ReadWaveNumer("Time", &timeWN)) {
-                                ERROR("Must provide TimeWaveNumber for synthetic turbulence\n");
-                                return -1;
+                                notice("TimeWaveNumber not provided for synthetic turbulence\n");
+                        } else {
+        			solver->lattice->ST.setTimeScale(timeWN);
                         }
-			solver->lattice->ST.setTimeScale(timeWN);
 		}
+		solver->lattice->GenerateST();
+
 		return 0;
 	}
 

--- a/src/Lattice.cu.Rt
+++ b/src/Lattice.cu.Rt
@@ -393,8 +393,6 @@ inline void Lattice::<?%s FunName ?>(int tab0, int tab1, int iter_type)
 	debug1("ZoneIter: %d (in <?%s FunName ?>)\n", ZoneIter);
 	container->ZoneIndex = ZoneIter;
 	container->MaxZones = zSet.MaxZones;
-	ST.Generate();
-	ST.CopyToGPU(container->ST);
 <?R
 	for (m in NonEmptyMargin) {
 ?>
@@ -479,8 +477,6 @@ inline void Lattice::<?%s FunName ?>_Adj(int tab0, int tab1, int adjtab0, int ad
 	ZoneIter = (Iter + Record_Iter) % zSet.getLen();
 	container->ZoneIndex = ZoneIter;
 	container->MaxZones = zSet.MaxZones;
-	ST.Generate();
-	ST.CopyToGPU(container->ST);
 
 	debug1("ZoneIter: %d (in <?%s FunName ?>_Adj)\n", ZoneIter);
 <?R
@@ -697,6 +693,7 @@ void Lattice::Init()
 	Iter = 0;
 	container->iter = 0;
 	clearGlobals();
+
 //   Stream();
 //   container->Init();
 //   Stream();
@@ -705,6 +702,12 @@ void Lattice::Init()
 void Lattice::BeforeIt()
 {
 }
+
+void Lattice::GenerateST() {
+	ST.Generate();
+	ST.CopyToGPU(container->ST);
+}
+
 
 /// Function for calculating the index of a Snapshot for a iteration
 int Lattice::getSnap(int i) {

--- a/src/Lattice.h.Rt
+++ b/src/Lattice.h.Rt
@@ -165,6 +165,7 @@ public:
 <?R for (v in rows(Settings)) { ?>
 	void <?%s v$FunName ?>(real_t);<?R
     } ?>
+  void GenerateST();
 };
 
 #define LATTICE_H 1

--- a/src/LatticeContainer.h.Rt
+++ b/src/LatticeContainer.h.Rt
@@ -114,10 +114,7 @@ class LatticeContainer {
   }
 
 
-  CudaDeviceFunction inline vector_t getST(const real_t t, int x, int y, int z) {
-	x += px;
-	y += py;
-	z += pz;
+  CudaDeviceFunction inline vector_t getST(real_t x, real_t y, real_t z) {
 	return calc(ST, x,y,z);
   }
 

--- a/src/cuda.cu.Rt
+++ b/src/cuda.cu.Rt
@@ -50,7 +50,8 @@ CudaDeviceFunction CudaConstantMemory real_t <?%s v$name ?> = 0.0f; <?R
 #define X (x_ + constContainer.px)
 #define Y (y_ + constContainer.py)
 #define Z (z_ + constContainer.pz)
-#define SyntheticTurbulence(t) constContainer.getST(t,x_,y_,z_)
+#define Time (constContainer.iter)
+#define SyntheticTurbulence(x__,y__,z__) constContainer.getST(x__,y__,z__)
 #define average_iter (constContainer.iter - constContainer.reset_iter)  //Look nicer in Dynamics
 <?R
 	for(s in rows(ZoneSettings)) { ?>


### PR DESCRIPTION
In the view of work with Paweł Obrępalski (@PabloOb ?), I decided that it is better to make the synthetic turbulence as a constant moving random field, and not exponentially convoluted in time as it was earlier.

I modified the procedures accordingly. I will test the spectra soon.