### PR TITLE
Adding device initialization in main (small fix)

### DIFF
--- a/src/main.cpp.Rt
+++ b/src/main.cpp.Rt
@@ -249,8 +249,10 @@ int main ( int argc, char * argv[] )
 		debug2("Selecting device %d/%d\n", dev, count);
 		CudaSetDevice( dev );
 		solver.mpi.gpu = dev;
-		debug2("Initializing device\n");
-		cudaFree(0);
+		#ifdef CROSS_GPU
+			debug2("Initializing device\n");
+			cudaFree(0);
+		#endif
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
 	DEBUG_M;

--- a/src/main.cpp.Rt
+++ b/src/main.cpp.Rt
@@ -249,6 +249,8 @@ int main ( int argc, char * argv[] )
 		debug2("Selecting device %d/%d\n", dev, count);
 		CudaSetDevice( dev );
 		solver.mpi.gpu = dev;
+		debug2("Initializing device\n");
+		cudaFree(0);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
 	DEBUG_M;


### PR DESCRIPTION
Added device initialization to that all driver issues would occur in main, and not in first CUDA call.