### PR TITLE
Adding dynamics access to Fields

### DIFF
--- a/src/LatticeAccess.inc.cpp.Rt
+++ b/src/LatticeAccess.inc.cpp.Rt
@@ -273,12 +273,15 @@ template <class N> CudaDeviceFunction void LatticeContainer::pop<?%s s$suffix ?>
  )
 
  
- txtlapply(rows(job_tab), function(job) {
-  f = Fields[[job$field]]
-  dx = job$dx
-  dy = job$dy
-  dz = job$dz
-#    for (f in Fields) for (dx in f$minx:f$maxx) for (dy in f$miny:f$maxy) for (dz in f$minz:f$maxz) { ?>
+# txtlapply(rows(job_tab), function(job) {
+#  f = Fields[[job$field]]
+#  dx = job$dx
+#  dy = job$dy
+#  dz = job$dz
+    for (f in Fields) {
+    for (dz in f$minz:f$maxz) {
+    for (dy in f$miny:f$maxy) {
+    for (dx in f$minx:f$maxx) { ?>
 template <> 
 CudaDeviceFunction real_t LatticeContainer::load_<?%s f$nicename ?> < <?%d dx ?>, <?%d dy ?>, <?%d dz ?> > (const int & x, const int & y, const int & z) 
 {
@@ -289,6 +292,38 @@ CudaDeviceFunction real_t LatticeContainer::load_<?%s f$nicename ?> < <?%d dx ?>
   con=load.field("ret", f, p, dp, con) ?>
   return ret;
 }
-<?R }) ?>
+<?R } ?>
+<?R } ?>
+<?R } ?>
+template <int DY, int DZ> 
+CudaDeviceFunction real_t LatticeContainer::load_<?%s f$nicename ?> (const int & x, const int & y, const int & z, const int & dx) 
+{
+  switch(dx) {
+<?R  for (dx in f$minx:f$maxx) { ?>
+    case <?%d dx ?>: return load_<?%s f$nicename ?> < <?%d dx ?>, DY, DZ > (x, y, z);
+<?R } ?>
+    default: return NAN;
+  }
+}
+template < int DZ > 
+CudaDeviceFunction real_t LatticeContainer::load_<?%s f$nicename ?> (const int & x, const int & y, const int & z, const int & dx, const int & dy) 
+{
+  switch(dy) {
+<?R  for (dy in f$miny:f$maxy) { ?>
+    case <?%d dy ?>: return load_<?%s f$nicename ?> < <?%d dy ?>, DZ > (x, y, z, dx);
+<?R } ?>
+    default: return NAN;
+  }
+}
+CudaDeviceFunction real_t LatticeContainer::load_<?%s f$nicename ?>  (const int & x, const int & y, const int & z, const int & dx, const int & dy, const int & dz) 
+{
+  switch(dz) {
+<?R  for (dz in f$minz:f$maxz) { ?>
+    case <?%d dz ?>: return load_<?%s f$nicename ?> < <?%d dz ?> > (x, y, z, dx, dy);
+<?R } ?>
+    default: return NAN;
+  }
+}
+<?R } ?>
 
 

--- a/src/LatticeContainer.h.Rt
+++ b/src/LatticeContainer.h.Rt
@@ -81,7 +81,14 @@ class LatticeContainer {
   CudaDeviceFunction real_t load_<?%s f$nicename ?> (const int & x, const int & y, const int & z) {
     typename Cannot_stream_the_field_in_the_direction_<DX,DY,DZ>::Field_name_<?%s f$nicename ?> Hej;
     return 0.0;
-  }; <?R
+  };
+  
+  template <int DY, int DZ>
+  CudaDeviceFunction real_t load_<?%s f$nicename ?> (const int & x, const int & y, const int & z, const int & dx);
+  template <int DZ>
+  CudaDeviceFunction real_t load_<?%s f$nicename ?> (const int & x, const int & y, const int & z, const int & dx, const int & dy);
+  CudaDeviceFunction real_t load_<?%s f$nicename ?> (const int & x, const int & y, const int & z, const int & dx, const int & dy, const int & dz);
+  <?R
   } ?>
 //  template <class N> CudaDeviceFunction void push_new(N & node);
 

--- a/src/cuda.cu.Rt
+++ b/src/cuda.cu.Rt
@@ -43,7 +43,10 @@ CudaDeviceFunction CudaConstantMemory real_t <?%s v$name ?> = 0.0f; <?R
         for (f in Fields) { ?>
 #define <?%s f$nicename ?>_3(x__,y__,z__) (constContainer.load_<?%s f$nicename ?> < x__, y__, z__ > (x_,y_,z_))
 #define <?%s f$nicename ?>_2(x__,y__) (constContainer.load_<?%s f$nicename ?> < x__, y__, 0 > (x_,y_,z_))
-#define <?%s f$nicename ?>(...) GET_MACRO(__VA_ARGS__, <?%s f$nicename ?>_3, <?%s f$nicename ?>_2)(__VA_ARGS__) <?R
+#define <?%s f$nicename ?>(...) GET_MACRO(__VA_ARGS__, <?%s f$nicename ?>_3, <?%s f$nicename ?>_2)(__VA_ARGS__)
+#define <?%s f$nicename ?>_dyn_3(x__,y__,z__) (constContainer.load_<?%s f$nicename ?> (x_,y_,z_,x__, y__, z__))
+#define <?%s f$nicename ?>_dyn_2(x__,y__) (constContainer.load_<?%s f$nicename ?> < 0 > (x_,y_,z_,x__, y__))
+#define <?%s f$nicename ?>_dyn(...) GET_MACRO(__VA_ARGS__, <?%s f$nicename ?>_dyn_3, <?%s f$nicename ?>_dyn_2)(__VA_ARGS__) <?R
         }
 ?>
 


### PR DESCRIPTION
For a given field `A` you can access the neighbours with eg. `A(-1,1)`. But the arguments have to be constant. This means that you cannot *loop over your neighbours*. I added dynamic accessors `A_dyn(dx,dy)`, which can be used with variables. Now you can do:
```c++
real_t sum=0;
for (int dx = -1; dx<=1; dx++) {
  for (int dy = -1; dy<=1; dy++) {
    sum += A_dyn(dx,dy);
  }
}
```
The function returns NAN if the field is accessed outside of it's accessible neighbourhood.