### PR TITLE
Fixing bug related to wide access (accessing data in wider regions)

### DIFF
--- a/src/LatticeContainer.inc.cpp.Rt
+++ b/src/LatticeContainer.inc.cpp.Rt
@@ -303,7 +303,7 @@ template <class N> CudaGlobalFunction void RunBorderKernel()
 <?R }
     if (tmaxz > tminz) { ?>
 	now.y_ = CudaBlock.x;
-	if ((now.y_ < constContainer.fy) && (now.y_ => constContainer.dy)) {
+	if ((now.y_ < constContainer.fy) && (now.y_ >= constContainer.dy)) {
 <?R	for (z in tminz:tmaxz) if (z < 0) { ?>
 		now.z_ = <?%d 0 - z ?>;
 		now.RunElement();

--- a/src/LatticeContainer.inc.cpp.Rt
+++ b/src/LatticeContainer.inc.cpp.Rt
@@ -1,6 +1,12 @@
 <?R
 	source("conf.R")
         c_header()
+    tminx = min(0,Fields$minx)
+    tmaxx = max(0,Fields$maxx)
+    tminy = min(0,Fields$miny)
+    tmaxy = max(0,Fields$maxy)
+    tminz = min(0,Fields$minz)
+    tmaxz = max(0,Fields$maxz)
 ?>
 /** \file LatticeContainer.cu
   File defining LatticeContainer and some additional CUDA functions
@@ -247,8 +253,8 @@ void LatticeContainer::Free()
 template <class N> CudaGlobalFunction void RunKernel()
 {
 	N now;
-	now.x_ = CudaThread.x+CudaBlock.z*CudaNumberOfThreads.x+constContainer.dx;
-	now.y_ = CudaThread.y+CudaBlock.x*CudaNumberOfThreads.y+constContainer.dy;
+	now.x_ = CudaThread.x + CudaBlock.z*CudaNumberOfThreads.x + constContainer.dx;
+	now.y_ = CudaThread.y + CudaBlock.x*CudaNumberOfThreads.y + constContainer.dy;
 	now.z_ = CudaBlock.y+constContainer.dz;
 	#ifndef GRID_3D
 		for (; now.x_ < constContainer.nx; now.x_ += CudaNumberOfThreads.x) {
@@ -273,51 +279,6 @@ template <class N> CudaGlobalFunction void RunKernel()
 // The model is 2D (no BORDER_Z)
 <?R } ?>
 
-/*
-// Border Kernel
-//   iterates over border elements and runs them with RunElement function
-template <class N> CudaGlobalFunction void RunBorderKernel()
-{
-	N now;
-	now.x_ = CudaThread.x + CudaBlock.y*X_BLOCK;
-	now.z_ = CudaBlock.x;
-	now.Pre();
-#ifdef BORDER_Z
-	if (now.z_ < constContainer.nz) {
-#endif
-		now.y_ = 0;
-		now.RunElement();
-#ifdef BORDER_Z
-	}
-#endif
-	now.Glob();
-	now.Pre();
-#ifdef BORDER_Z
-	if (now.z_ < constContainer.nz) {
-#endif
-		now.y_ = constContainer.ny - 1;
-		now.RunElement();
-#ifdef BORDER_Z
-	}
-#endif
-	now.Glob();
-	now.Pre();
-#ifdef BORDER_Z
-	now.y_ = CudaBlock.x;
-	if ((now.y_ < constContainer.ny-1) && (now.y_ > 0)) {
-		now.z_ = 0;
-                now.RunElement();
-	}
-	now.Glob();
-	now.Pre();
-	if ((now.y_ < constContainer.ny-1) && (now.y_ > 0)) {
-                now.z_ = constContainer.nz - 1;
-                now.RunElement();
-	}
-	now.Glob();
-#endif
-}
-*/
 
 /// Border Kernel
 /**
@@ -329,23 +290,29 @@ template <class N> CudaGlobalFunction void RunBorderKernel()
 	now.x_ = CudaThread.x + CudaBlock.y*X_BLOCK;
 	now.z_ = CudaBlock.x;
 	now.Pre();
-#ifdef BORDER_Z
+<?R if (tmaxy > tminy) { ?>
 	if (now.z_ < constContainer.nz) {
-#endif
-		now.y_ = 0;
+<?R	for (y in tminy:tmaxy) if (y < 0) { ?>
+		now.y_ = <?%d 0 - y ?>;
 		now.RunElement();
-		now.y_ = constContainer.ny - 1;
+<?R	} else if (y > 0) { ?>
+		now.y_ = constContainer.ny - <?%d y ?>;
 		now.RunElement();
-#ifdef BORDER_Z
+<?R	} ?>
 	}
+<?R }
+    if (tmaxz > tminz) { ?>
 	now.y_ = CudaBlock.x;
-	if ((now.y_ < constContainer.ny-1) && (now.y_ > 0)) {
-		now.z_ = 0;
-                now.RunElement();
-                now.z_ = constContainer.nz - 1;
-                now.RunElement();
+	if ((now.y_ < constContainer.fy) && (now.y_ => constContainer.dy)) {
+<?R	for (z in tminz:tmaxz) if (z < 0) { ?>
+		now.z_ = <?%d 0 - z ?>;
+		now.RunElement();
+<?R	} else if (z > 0) { ?>
+		now.z_ = constContainer.nz - <?%d z ?>;
+		now.RunElement();
+<?R	} ?>
 	}
-#endif
+<?R } ?>
 	now.Glob();
 }
 
@@ -355,16 +322,12 @@ template <class N> CudaGlobalFunction void RunBorderKernel()
   in the constant memory of the GPU
 */
 void LatticeContainer::CopyToConst() {
-    fx=nx;
-    fy=ny-1;
-    dx = 0; dy = 1; 
-    #ifdef BORDER_Z
-	dz = 1;
-	fz = nz - 1;
-    #else
-	dz = 0;
-	fz = nz;
-    #endif
+    dx =  0;
+    fx = nx;
+    dy = <?%d -tminy ?>;
+    fy = ny - <?%d tmaxy ?>;
+    dz = <?%d -tminz ?>;
+    fz = nz - <?%d tmaxz ?>;
     CudaCopyToConstant("constContainer", constContainer, this, sizeof(LatticeContainer));
 }
 
@@ -389,11 +352,7 @@ template <class N> inline void LatticeContainer::RunBorderT(CudaStream_t borderS
 template <class N> inline void LatticeContainer::RunInteriorT(CudaStream_t interiorStream) {
     int nnz;
     ky = ThreadNumber< N >::getKY();
-    #ifdef BORDER_Z
-	nnz = nz - 2;
-    #else
-	nnz = nz;
-    #endif
+    nnz = fz - dz;
     #ifdef GRID_3D
         CudaKernelRunNoWait( RunKernel<N> , dim3(ky, nnz, kx) , dim3(X_BLOCK,ThreadNumber< N >::getSY()),(),interiorStream);
     #else

--- a/src/LatticeContainer.inc.cpp.Rt
+++ b/src/LatticeContainer.inc.cpp.Rt
@@ -292,11 +292,11 @@ template <class N> CudaGlobalFunction void RunBorderKernel()
 	now.Pre();
 <?R if (tmaxy > tminy) { ?>
 	if (now.z_ < constContainer.nz) {
-<?R	for (y in tminy:tmaxy) if (y < 0) { ?>
-		now.y_ = <?%d 0 - y ?>;
+<?R	for (y in tminy:tmaxy) if (y > 0) { ?>
+		now.y_ = <?%d y - 1 ?>;
 		now.RunElement();
-<?R	} else if (y > 0) { ?>
-		now.y_ = constContainer.ny - <?%d y ?>;
+<?R	} else if (y < 0) { ?>
+		now.y_ = constContainer.ny - <?%d -y ?>;
 		now.RunElement();
 <?R	} ?>
 	}
@@ -304,11 +304,11 @@ template <class N> CudaGlobalFunction void RunBorderKernel()
     if (tmaxz > tminz) { ?>
 	now.y_ = CudaBlock.x;
 	if ((now.y_ < constContainer.fy) && (now.y_ >= constContainer.dy)) {
-<?R	for (z in tminz:tmaxz) if (z < 0) { ?>
-		now.z_ = <?%d 0 - z ?>;
+<?R	for (z in tminz:tmaxz) if (z > 0) { ?>
+		now.z_ = <?%d z - 1 ?>;
 		now.RunElement();
-<?R	} else if (z > 0) { ?>
-		now.z_ = constContainer.nz - <?%d z ?>;
+<?R	} else if (z < 0) { ?>
+		now.z_ = constContainer.nz - <?%d -z ?>;
 		now.RunElement();
 <?R	} ?>
 	}
@@ -324,10 +324,10 @@ template <class N> CudaGlobalFunction void RunBorderKernel()
 void LatticeContainer::CopyToConst() {
     dx =  0;
     fx = nx;
-    dy = <?%d -tminy ?>;
-    fy = ny - <?%d tmaxy ?>;
-    dz = <?%d -tminz ?>;
-    fz = nz - <?%d tmaxz ?>;
+    dy = <?%d tmaxy ?>;
+    fy = ny - <?%d -tminy ?>;
+    dz = <?%d tmaxz ?>;
+    fz = nz - <?%d -tminz ?>;
     CudaCopyToConstant("constContainer", constContainer, this, sizeof(LatticeContainer));
 }
 

--- a/src/conf.R
+++ b/src/conf.R
@@ -655,8 +655,8 @@ offsets = function(d2=FALSE, cpu=FALSE) {
 	{
 		mins = c(f$minx,f$miny,f$minz)
 		maxs = c(f$maxx,f$maxy,f$maxz)
-		tab1 = c(0,0,0,ifelse(mins > 0 & maxs > 0,-1,0),ifelse(maxs > 0,1,0))
-		tab2 = c(ifelse(mins < 0,1,0),ifelse(maxs < 0 & mins < 0,-1,0),0,0,0)
+		tab1 = c(0,0,0,ifelse(mins == maxs & maxs > 0,-1,0),ifelse(maxs > 0,1,0))
+		tab2 = c(ifelse(mins < 0,1,0),ifelse(maxs == mins & mins < 0,-1,0),0,0,0)
 		tab3 = c(mins<0,TRUE,TRUE,TRUE,maxs>0)
 		put_tab = cbind(tab1[p$x],tab1[p$y],tab1[p$z],tab2[p$x],tab2[p$y],tab2[p$z])
 		put_sel = tab3[p$x] & tab3[p$y] & tab3[p$z]


### PR DESCRIPTION
### Interior/Border
Corrected the division between Interior and Border elements, for access directions with dy/dz values higher then 1

## Wide access all on one side
Fixed a bug, which was causing wrong access conditions if the dx/dy/dz were all eigther positive or negative, and had a spread. E.g. `minx=-2` and `maxx=-1`