### PR TITLE
[V6.2 RC] Extend flag_t

### DIFF
--- a/models/experimental/d2q9_inc/Dynamics.R
+++ b/models/experimental/d2q9_inc/Dynamics.R
@@ -48,3 +48,5 @@ AddSetting(name="S78", default="0", comment='MRT Sx')
 
 AddNodeType(name="BottomSymmetry",group="BOUNDARY")
 AddNodeType(name="TopSymmetry",group="BOUNDARY")
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/models/flow/d2q9/Dynamics.R
+++ b/models/flow/d2q9/Dynamics.R
@@ -77,3 +77,6 @@ AddNodeType(name="EVelocity", group="BOUNDARY")
 
 AddNodeType(name="NSymmetry", group="BOUNDARY")
 AddNodeType(name="SSymmetry", group="BOUNDARY")
+
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/models/flow/d2q9_les/Dynamics.R
+++ b/models/flow/d2q9_les/Dynamics.R
@@ -28,3 +28,5 @@ AddGlobal(name="TotalPressureFlux", comment='pressure loss')
 AddGlobal(name="OutletFlux", comment='pressure loss')
 AddGlobal(name="InletPressureIntegral", comment='pressure loss')
 
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/models/flow/d2q9_thin_film/Dynamics.R
+++ b/models/flow/d2q9_thin_film/Dynamics.R
@@ -94,3 +94,5 @@ AddNodeType(name="SSymmetry", group="BOUNDARY")
 
 
 AddNodeType(name="Cumulant", group="COLLISION")
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/models/multiphase/d2q9_pf/Dynamics.R
+++ b/models/multiphase/d2q9_pf/Dynamics.R
@@ -108,3 +108,5 @@ AddNodeType(name="EPressure",group="BOUNDARY")
 
 AddNodeType(name="WVelocity",group="BOUNDARY")
 AddNodeType(name="EVelocity",group="BOUNDARY")
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/models/optimization/d2q9_adj/Dynamics.R
+++ b/models/optimization/d2q9_adj/Dynamics.R
@@ -38,3 +38,5 @@ AddSetting(name="PorocityTheta", comment='theta in hiperbolic transformation of 
 AddSetting(name="Porocity", comment='initial porocity of Porous nodes', zonal=TRUE)
 
 #AddNodeType(name="MovingWall", group="BOUNDARY")
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/models/optimization/d3q19_adj/Dynamics.R
+++ b/models/optimization/d3q19_adj/Dynamics.R
@@ -153,3 +153,6 @@ AddGlobal(name="EnergyFlux", comment='pressure loss')
 AddGlobal(name="PressureFlux", comment='pressure loss')
 AddGlobal(name="PressureDiff", comment='pressure loss')
 AddGlobal(name="MaterialPenalty", comment='quadratic penalty for intermediate material parameter')
+
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/src/Consts.h.Rt
+++ b/src/Consts.h.Rt
@@ -23,11 +23,21 @@
 #endif
 
 <?R
+  big_hex = function(x,bits=16) {
+    ret = ""
+    while (x > 0 | bits > 0) {
+      a = x %% 16
+      ret = sprintf("%01x%s",a,ret)
+      x = (x-a) / 16
+      bits = bits - 4
+    }
+    ret
+  }
   for (n in names(Node)) { ?>
-#define NODE_<?%-20s n ?> 0x<?%08x Node[n] ?> <?R
+#define NODE_<?%-20s n ?> 0x<?%s big_hex(Node[n]) ?> <?R
   }
   for (n in names(Node_Group)) { ?>
-#define NODE_<?%-20s n ?> 0x<?%08x Node_Group[n] ?> <?R
+#define NODE_<?%-20s n ?> 0x<?%s big_hex(Node_Group[n]) ?> <?R
   }
 ?>
 <?R

--- a/src/LatticeAccess.inc.cpp.Rt
+++ b/src/LatticeAccess.inc.cpp.Rt
@@ -350,22 +350,33 @@ CudaDeviceFunction real_t LatticeContainer::load_<?%s f$nicename ?>  (const int 
 
 <?R
 if (Options$autosym) {
-  sym_load = function(f,d,i) {
-   if (i > 3) { ?>
+  sym_load = function(f,d,i,sig=1) {
+   if (i > 3) {
+    if (sig < 0) { ?>
+    return -load0_<?%s f$nicename ?> < <?%d d[1] ?>, <?%d d[2] ?>, <?%d d[3] ?> > (x,y,z,nt);
+<?R } else { ?>
     return load0_<?%s f$nicename ?> < <?%d d[1] ?>, <?%d d[2] ?>, <?%d d[3] ?> > (x,y,z,nt);
-   <?R } else {
+<?R }
+   } else {
     s = names(symmetries)[i]
-    si = which(Fields$name == f[[s]])
+    fn = f[[s]]
+    if (substr(fn,1,1) == "-") {
+     nsig = -1;
+     fn = substr(fn,2,nchar(fn))
+    } else {
+     nsig = 1;
+    }
+    si = which(Fields$name == fn)
     sf = rows(Fields)[[si]]
     sd = d
     sd[i] = -sd[i]
     ch = c("X","Y","Z")[i]
     if (d[i] > 0) { ?>
-    if ((nt & NODE_SYM<?%s ch ?>) == NODE_Symmetry<?%s ch ?>_plus) { <?R sym_load(sf,sd,i+1) ?> }
+    if ((nt & NODE_SYM<?%s ch ?>) == NODE_Symmetry<?%s ch ?>_plus) { <?R sym_load(sf,sd,i+1,sig*nsig) ?> }
     <?R } else if (d[i] < 0) { ?>
-    if ((nt & NODE_SYM<?%s ch ?>) == NODE_Symmetry<?%s ch ?>_minus) { <?R sym_load(sf,sd,i+1) ?> }
+    if ((nt & NODE_SYM<?%s ch ?>) == NODE_Symmetry<?%s ch ?>_minus) { <?R sym_load(sf,sd,i+1,sig*nsig) ?> }
     <?R } ?>
-    <?R sym_load(f,d,i+1)
+    <?R sym_load(f,d,i+1,sig)
     }
   }
 

--- a/src/conf.R
+++ b/src/conf.R
@@ -302,13 +302,13 @@ AddNodeType("EVelocity","BOUNDARY")
 # AddNodeType("Wet","ADDITIONALS")
 # AddNodeType("Dry","ADDITIONALS")
 # AddNodeType("Propagate","ADDITIONALS")
-AddNodeType("Inlet","OBJECTIVE")
-AddNodeType("Outlet","OBJECTIVE")
+#AddNodeType("Inlet","OBJECTIVE")
+#AddNodeType("Outlet","OBJECTIVE")
 # AddNodeType("Obj1","OBJECTIVE")
 # AddNodeType("Obj2","OBJECTIVE")
 # AddNodeType("Obj3","OBJECTIVE")
 # AddNodeType("Thermometer","OBJECTIVE")
-AddNodeType("DesignSpace","DESIGNSPACE")
+#AddNodeType("DesignSpace","DESIGNSPACE")
 
 Stages=NULL
 
@@ -398,12 +398,16 @@ if (Options$autosym) { ## Automatic symmetries
     for (d in rows(D)) {
       v = c(d$dx,d$dy,d$dz)
       for (s in names(symmetries)) if (d[[s]] == "") {
-        s_v = v * symmetries[,s]
-        s_sel = (D$dx == s_v[1]) & (D$dy == s_v[2]) & (D$dz == s_v[3])
-        if (sum(s_sel) == 0) stop("Could not find symmetry for density",d$name)
-        if (sum(s_sel) > 1) stop("Too many symmetries for density",d$name)
-        i = which(s_sel)
-        s_d = D[s_sel,,drop=FALSE]
+	if (all(v == 0)) {
+		s_d = d
+	} else {
+          s_v = v * symmetries[,s]
+          s_sel = (D$dx == s_v[1]) & (D$dy == s_v[2]) & (D$dz == s_v[3])
+          if (sum(s_sel) == 0) stop("Could not find symmetry for density",d$name)
+          if (sum(s_sel) > 1) stop("Too many symmetries for density",d$name)
+          i = which(s_sel)
+          s_d = D[s_sel,,drop=FALSE]
+	}
         DensityAll[DensityAll$name == d$name,s] = s_d$name
         if (Fields[Fields$name == d$field,s] == "") Fields[Fields$name == d$field,s] = s_d$field
       }
@@ -412,7 +416,7 @@ if (Options$autosym) { ## Automatic symmetries
 
   for (s in names(symmetries)) {
     sel = Fields[,s] == ""
-    Fields[sel,s] = Fields$name[s]
+    Fields[sel,s] = Fields$name[sel]
   }
 
   AddNodeType("SymmetryX_plus",  group="SYMX")

--- a/src/conf.R
+++ b/src/conf.R
@@ -308,7 +308,7 @@ AddNodeType("EVelocity","BOUNDARY")
 # AddNodeType("Obj2","OBJECTIVE")
 # AddNodeType("Obj3","OBJECTIVE")
 # AddNodeType("Thermometer","OBJECTIVE")
-#AddNodeType("DesignSpace","DESIGNSPACE")
+AddNodeType("DesignSpace","DESIGNSPACE")
 
 Stages=NULL
 
@@ -488,13 +488,15 @@ NodeTypes = do.call(rbind, by(NodeTypes,NodeTypes$group,function(tab) {
 	tab
 }))
 FlagT = "unsigned short int"
+FlagTBits = 16
 if (NodeShiftNum > 14) {
 	FlagT = "unsigned int"
+	FlagTBits = 32
 	if (NodeShiftNum > 30) {
 		stop("NodeTypes exceeds 32 bits")
 	}
 }
-ZoneBits = 16 - NodeShiftNum
+ZoneBits = FlagTBits - NodeShiftNum
 ZoneShift = NodeShiftNum
 if (ZoneBits == 0) warning("No additional zones! (too many node types) - it will run, but you cannot use local settings")
 ZoneMax = 2^ZoneBits
@@ -507,10 +509,10 @@ NodeTypes = rbind(NodeTypes,data.frame(
         mask=(ZoneMax-1)*NodeShift,
         shift=NodeShiftNum
 ))
-NodeShiftNum = 16
+NodeShiftNum = FlagTBits
 NodeShift = 2^NodeShiftNum
 
-if (any(NodeTypes$value >= 2^16)) stop("NodeTypes exceeds short int")
+if (any(NodeTypes$value >= 2^FlagTBits)) stop("NodeTypes exceeds short int")
 
 NodeTypes = rbind(NodeTypes, data.frame(
 	name="None",

--- a/src/conf.R
+++ b/src/conf.R
@@ -487,36 +487,28 @@ NodeTypes = do.call(rbind, by(NodeTypes,NodeTypes$group,function(tab) {
 	NodeShiftNum <<- NodeShiftNum + l
 	tab
 }))
-
-if (NodeShiftNum > 16) {
-	stop("NodeTypes exceeds short int")
-} else {
-	ZoneBits = 16 - NodeShiftNum
-	ZoneShift = NodeShiftNum
-	if (ZoneBits == 0) warning("No additional zones! (too many node types) - it will run, but you cannot use local settings")
-	ZoneMax = 2^ZoneBits
-#	ZoneRange = 1:ZoneMax
-#	NodeTypes = rbind(NodeTypes,data.frame(
-#		name=paste("SettingZone",ZoneRange,sep=""),
-#		group="SETTINGZONE",
-#		index=ZoneRange,
-#		Index=paste("SettingZone",ZoneRange,sep=""),
-#		value=(ZoneRange-1)*NodeShift,
-#		mask=(ZoneMax-1)*NodeShift,
-#		shift=NodeShiftNum
-#	))
-	NodeTypes = rbind(NodeTypes,data.frame(
-		name="DefaultZone",
-		group="SETTINGZONE",
-		index=1,
-		Index="DefaultZone",
-		value=0,
-		mask=(ZoneMax-1)*NodeShift,
-		shift=NodeShiftNum
-	))
-	NodeShiftNum = 16
-	NodeShift = 2^NodeShiftNum
+FlagT = "unsigned short int"
+if (NodeShiftNum > 14) {
+	FlagT = "unsigned int"
+	if (NodeShiftNum > 30) {
+		stop("NodeTypes exceeds 32 bits")
+	}
 }
+ZoneBits = 16 - NodeShiftNum
+ZoneShift = NodeShiftNum
+if (ZoneBits == 0) warning("No additional zones! (too many node types) - it will run, but you cannot use local settings")
+ZoneMax = 2^ZoneBits
+NodeTypes = rbind(NodeTypes,data.frame(
+        name="DefaultZone",
+        group="SETTINGZONE",
+        index=1,
+        Index="DefaultZone",
+        value=0,
+        mask=(ZoneMax-1)*NodeShift,
+        shift=NodeShiftNum
+))
+NodeShiftNum = 16
+NodeShift = 2^NodeShiftNum
 
 if (any(NodeTypes$value >= 2^16)) stop("NodeTypes exceeds short int")
 

--- a/src/cuda.cu.Rt
+++ b/src/cuda.cu.Rt
@@ -50,9 +50,9 @@ CudaDeviceFunction CudaConstantMemory real_t <?%s v$name ?> = 0.0f; <?R
         }
 ?>
 
-#define X (x_ + constContainer.px)
-#define Y (y_ + constContainer.py)
-#define Z (z_ + constContainer.pz)
+#define X ((real_t) x_ + constContainer.px + 0.5)
+#define Y ((real_t) y_ + constContainer.py + 0.5)
+#define Z ((real_t) z_ + constContainer.pz + 0.5)
 #define Time (constContainer.iter)
 #define SyntheticTurbulence(x__,y__,z__) constContainer.getST(x__,y__,z__)
 #define average_iter (constContainer.iter - constContainer.reset_iter)  //Look nicer in Dynamics

--- a/src/def.cpp.Rt
+++ b/src/def.cpp.Rt
@@ -23,7 +23,7 @@ const char* xml_definition = "<Geometry>\
 	<Zone name='Tunnel'> <Box dx='0' dy='0' dz='0' fx='0' fy='-1' fz='-1'/></Zone>\
 	<Zone name='Inlet'><Box dx='0' dy='0' dz='0' fx='0' fy='-1' fz='-1'/></Zone>\
 <?R for (i in 1:length(Node_Group)) {
-?>	<Mask name='<?%s names(Node_Group)[i]?>' value='<?%d Node_Group[i]?>'/>\
+?>	<Mask name='<?%s names(Node_Group)[i]?>' value='<?%f Node_Group[i]?>'/>\
 <?R }
     for (i in 1:length(Node)) { x = Node_Group; x = x[x >= Node[i]];
 ?>	<Type name='<?%s names(Node)[i]?>' value='<?%d Node[i]?>' mask='<?%s names(x)[which.min(x)]?>'/>\

--- a/src/types.h.Rt
+++ b/src/types.h.Rt
@@ -1,3 +1,4 @@
+<?R source("conf.R") ?>
 #ifndef TYPES_H
   #define TYPES_H
 
@@ -11,7 +12,7 @@
 //  typedef struct {real_t x,y,z;} vector_t_b;
 
 //  typedef char flag_t;
-  typedef unsigned short int flag_t;
+  typedef <?%s FlagT ?> flag_t;
 
   typedef unsigned char cut_t;
   

--- a/src/vtkOutput.h
+++ b/src/vtkOutput.h
@@ -36,7 +36,7 @@ public:
 	inline void WriteField(char * name, unsigned char * data) { WriteField(name, (void*) data, sizeof(char), "UInt8", 1); };
 	inline void WriteField(char * name, short int * data) { WriteField(name, (void*) data, sizeof(short int), "Int16", 1); };
 	inline void WriteField(char * name, unsigned short int * data) { WriteField(name, (void*) data, sizeof(unsigned short int), "UInt16", 1); };
-	inline void WriteField(char * name, unsigned int * data) { WriteField(name, (void*) data, sizeof(unsigned short int), "UInt32", 1); };
+	inline void WriteField(char * name, unsigned int * data) { WriteField(name, (void*) data, sizeof(unsigned int), "UInt32", 1); };
 	void Finish();
 	void Close();
 };

--- a/src/vtkOutput.h
+++ b/src/vtkOutput.h
@@ -36,6 +36,7 @@ public:
 	inline void WriteField(char * name, unsigned char * data) { WriteField(name, (void*) data, sizeof(char), "UInt8", 1); };
 	inline void WriteField(char * name, short int * data) { WriteField(name, (void*) data, sizeof(short int), "Int16", 1); };
 	inline void WriteField(char * name, unsigned short int * data) { WriteField(name, (void*) data, sizeof(unsigned short int), "UInt16", 1); };
+	inline void WriteField(char * name, unsigned int * data) { WriteField(name, (void*) data, sizeof(unsigned short int), "UInt32", 1); };
 	void Finish();
 	void Close();
 };


### PR DESCRIPTION
If there is too many NodeTypes, `conf.R` will use `unsigned int` instead of `unsigned short int`.

### Additionally
- Moved Inlet and Outlet node types to the relevant models
- Moved X,Y,Z by 0.5 (to the center of the cell) for a more natural syntax.