### PR TITLE
Update of d3q27_pf_velocity for three-phase contact

### DIFF
--- a/example/multiphase/csf/ContactAngle_45.xml
+++ b/example/multiphase/csf/ContactAngle_45.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<CLBConfig version="2.0" output="output/">
+<!-- MODEL: d3q27_pf_velocity
+     Solid contact angle example
+	Created: 14/12/2017
+     	Responsible: @TravisMitchell
+-->
+	<Geometry nx="128" ny="64" nz="128" >
+		<MRT>
+			<Box />
+		</MRT>
+		<Wall mask="ALL" name="Upper">
+			<Box dy="-1" />
+		</Wall>
+		<Wall mask="ALL" name="Lower">
+			<Box ny="1" />
+		</Wall>
+	</Geometry>
+	<Model>
+		<Params 
+	Density_h="1" Density_l="0.001" 
+	PhaseField="0.0" PhaseField-droplet="1.0" 
+
+	ContactAngle="45" 
+
+	IntWidth="4" M="0.05" sigma="5e-5" 
+	Viscosity_l="0.0166" Viscosity_h="0.166"
+	
+	Radius="24"
+	CenterX="64"
+	CenterY="0"
+	CenterZ="64"
+	/>
+	</Model>
+	<VTK />
+	<Failcheck Iterations="1000" />
+	<Solve Iterations="200000">
+	<VTK   Iterations="10000"/>
+	</Solve>
+</CLBConfig>

--- a/example/multiphase/csf/ContactAngle_45_symX.xml
+++ b/example/multiphase/csf/ContactAngle_45_symX.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<CLBConfig version="2.0" output="output/">
+<!-- MODEL: d3q27_pf_velocity_autosym
+     Solid contact angle example to test out symmetry
+     in single plane.
+        Created: 14/12/2017
+        Responsible: @TravisMitchell
+-->
+	<Geometry nx="64" ny="64" nz="128" >
+		<MRT>
+			<Box />
+		</MRT>
+		<SymmetryX_plus>
+			<Box dx="-1"/>
+		</SymmetryX_plus>
+		<SymmetryX_minus>
+			<Box nx="1"/>
+		</SymmetryX_minus>
+		<Wall mask="ALL" name="Upper">
+			<Box dy="-1" />
+		</Wall>
+		<Wall mask="ALL" name="Lower">
+			<Box ny="1" />
+		</Wall>
+	</Geometry>
+	<Model>
+		<Params 
+	Density_h="1" Density_l="0.001" 
+
+	ContactAngle="45" 
+	IntWidth="4" M="0.05" sigma="5e-5" 
+	Viscosity_l="0.0166" Viscosity_h="0.166"
+	
+	Radius="24"
+	CenterX="64"
+	CenterY="0"
+	CenterZ="64"
+	/>
+	</Model>
+	<VTK />
+	<Failcheck Iterations="1000" />
+	<Solve Iterations="200000">
+	<VTK   Iterations="10000"/>
+	</Solve>
+</CLBConfig>

--- a/example/multiphase/csf/ContactAngle_45_symXZ.xml
+++ b/example/multiphase/csf/ContactAngle_45_symXZ.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<CLBConfig version="2.0" output="output/">
+<!-- MODEL: d3q27_pf_velocity_autosym
+          Solid contact angle example to test out symmetry
+     in two planes.
+        Created: 14/12/2017
+        Responsible: @TravisMitchell
+-->
+	<Geometry nx="64" ny="64" nz="64" >
+		<MRT>
+			<Box />
+		</MRT>
+		<SymmetryX_plus>
+			<Box dx="-1"/>
+		</SymmetryX_plus>
+		<SymmetryX_minus>
+			<Box nx="1"/>
+		</SymmetryX_minus>
+		<SymmetryZ_plus>
+			<Box dz="-1"/>
+		</SymmetryZ_plus>
+		<SymmetryZ_minus>
+			<Box nz="1"/>
+		</SymmetryZ_minus>
+		<Wall mask="ALL" name="Upper">
+			<Box dy="-1" />
+		</Wall>
+		<Wall mask="ALL" name="Lower">
+			<Box ny="1" />
+		</Wall>
+	</Geometry>
+	<Model>
+	<Params 
+		Density_h="1" Density_l="0.001" 
+
+		ContactAngle="45" 
+	
+		IntWidth="4" M="0.05" sigma="5e-5" 
+		Viscosity_l="0.0166" Viscosity_h="0.166"
+	
+		Radius="24"
+		CenterX="64"
+		CenterY="0"
+		CenterZ="64"
+	/>
+	</Model>
+	<VTK />
+	<Failcheck Iterations="1000" />
+	<Solve Iterations="200000">
+	<VTK   Iterations="10000"/>
+	</Solve>
+</CLBConfig>

--- a/models/experimental/d2q9_inc/Dynamics.R
+++ b/models/experimental/d2q9_inc/Dynamics.R
@@ -48,3 +48,5 @@ AddSetting(name="S78", default="0", comment='MRT Sx')
 
 AddNodeType(name="BottomSymmetry",group="BOUNDARY")
 AddNodeType(name="TopSymmetry",group="BOUNDARY")
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/models/flow/d2q9/Dynamics.R
+++ b/models/flow/d2q9/Dynamics.R
@@ -77,3 +77,6 @@ AddNodeType(name="EVelocity", group="BOUNDARY")
 
 AddNodeType(name="NSymmetry", group="BOUNDARY")
 AddNodeType(name="SSymmetry", group="BOUNDARY")
+
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/models/flow/d2q9_les/Dynamics.R
+++ b/models/flow/d2q9_les/Dynamics.R
@@ -28,3 +28,5 @@ AddGlobal(name="TotalPressureFlux", comment='pressure loss')
 AddGlobal(name="OutletFlux", comment='pressure loss')
 AddGlobal(name="InletPressureIntegral", comment='pressure loss')
 
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/models/flow/d2q9_thin_film/Dynamics.R
+++ b/models/flow/d2q9_thin_film/Dynamics.R
@@ -94,3 +94,5 @@ AddNodeType(name="SSymmetry", group="BOUNDARY")
 
 
 AddNodeType(name="Cumulant", group="COLLISION")
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/models/multiphase/d2q9_pf/Dynamics.R
+++ b/models/multiphase/d2q9_pf/Dynamics.R
@@ -108,3 +108,5 @@ AddNodeType(name="EPressure",group="BOUNDARY")
 
 AddNodeType(name="WVelocity",group="BOUNDARY")
 AddNodeType(name="EVelocity",group="BOUNDARY")
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/models/multiphase/d3q27_pf_velocity/Dynamics.R
+++ b/models/multiphase/d3q27_pf_velocity/Dynamics.R
@@ -62,8 +62,8 @@ AddStage("WallInit"  , "Init_wallNorm", save=Fields$group=="nw")
 
 AddStage("calcWall"  , "calcWallPhase", save="PhaseF", load=DensityAll$group=="nw")
 AddStage("calcPhase" , "calcPhaseF",	save="PhaseF", load=DensityAll$group=="h" )
-AddStage("BaseIter"  , "Run"       ,    save=Fields$group %in% c("g","h","Vel"), 
-	                                load=DensityAll$group %in% c("g","h","Vel"))
+AddStage("BaseIter"  , "Run"       ,    save=Fields$group %in% c("g","h","Vel","nw"), 
+	                                load=DensityAll$group %in% c("g","h","Vel","nw"))
 
 if (Options$SC) {
 AddStage("WallPhase", "calcWallPhase", save="PhaseF")

--- a/models/multiphase/d3q27_pf_velocity/Dynamics.R
+++ b/models/multiphase/d3q27_pf_velocity/Dynamics.R
@@ -49,30 +49,36 @@ AddDensity(name="U", dx=0, dy=0, dz=0, group="Vel")
 AddDensity(name="V", dx=0, dy=0, dz=0, group="Vel")
 AddDensity(name="W", dx=0, dy=0, dz=0, group="Vel")
 
+AddDensity(name="nw_x", dx=0, dy=0, dz=0, group="nw")
+AddDensity(name="nw_y", dx=0, dy=0, dz=0, group="nw")
+AddDensity(name="nw_z", dx=0, dy=0, dz=0, group="nw")
+
 AddField('PhaseF',stencil3d=1, group="OrderParameter")
 
 # Stages - processes to run for initialisation and each iteration
-AddStage("PhaseInit"    , "Init", save="PhaseF")
-AddStage("BaseInit"     , "Init_distributions", save=Fields$group=="g" | Fields$group=="h" | Fields$group=="Vel")
-AddStage("calcPhase"	, "calcPhaseF",	save='PhaseF'                             , 
-	load=DensityAll$group=="h")
-AddStage("BaseIter"     , "Run" , save=Fields$group=="g" | Fields$group=="h" | Fields$group=="Vel", 
-	load=DensityAll$group=="g" | DensityAll$group=="h" | DensityAll$group=="Vel")
+AddStage("PhaseInit" , "Init", save="PhaseF")
+AddStage("BaseInit"  , "Init_distributions", save=Fields$group %in% c("g","h","Vel"))
+AddStage("WallInit"  , "Init_wallNorm", save=Fields$group=="nw")
+
+AddStage("calcWall"  , "calcWallPhase", save="PhaseF", load=DensityAll$group=="nw")
+AddStage("calcPhase" , "calcPhaseF",	save="PhaseF", load=DensityAll$group=="h" )
+AddStage("BaseIter"  , "Run"       ,    save=Fields$group %in% c("g","h","Vel"), 
+	                                load=DensityAll$group %in% c("g","h","Vel"))
 
 if (Options$SC) {
 AddStage("WallPhase", "calcWallPhase", save="PhaseF")
 AddAction("Iteration", c("BaseIter", "calcPhase", "WallPhase"))
 AddAction("Init"     , c("PhaseInit", "WallPhase","BaseInit", "calcPhase"))
 } else {
-AddAction("Iteration", c("BaseIter", "calcPhase"))
-AddAction("Init"     , c("PhaseInit","BaseInit", "calcPhase"))
+AddAction("Iteration", c("BaseIter", "calcPhase", "calcWall"))
+AddAction("Init"     , c("PhaseInit","WallInit","calcWall","BaseInit"))
 }
 
 # 	Outputs:
 AddQuantity(name="PhaseField",unit="1")
 AddQuantity(name="U",	  unit="m/s",vector=T)
 AddQuantity(name="P",	  unit="Pa")
-
+AddQuantity(name="Normal", unit=1, vector=T)
 #	Inputs: For phasefield evolution
 AddSetting(name="Density_h", comment='High density')
 AddSetting(name="Density_l", comment='Low  density')
@@ -83,6 +89,9 @@ AddSetting(name="IntWidth", default=4,    comment='Anti-diffusivity coeff')
 AddSetting(name="omega_phi", comment='one over relaxation time (phase field)')
 AddSetting(name="M", omega_phi='1.0/(3*M+0.5)', default=0.02, comment='Mobility')
 AddSetting(name="sigma", 		   comment='surface tension')
+
+AddSetting(name="ContactAngle", radAngle='ContactAngle*3.1415926535897/180', default='90', comment='Contact angle in degrees')
+AddSetting(name='radAngle', comment='Conversion to rads for calcs')
 
 if (Options$SC) {
 AddSetting(name="ContactAngle", default="90", comment='Contact angle of the phases')
@@ -131,8 +140,6 @@ AddNodeType("Bubbletrack",group="ADDITIONALS")
 
 AddNodeType(name="MovingWall_N", group="BOUNDARY")
 AddNodeType(name="MovingWall_S", group="BOUNDARY")
-AddNodeType(name="SymmetricXY_W",group="ADDITIONALS")
-AddNodeType(name="SymmetricXY_E",group="ADDITIONALS")
 
 AddGlobal("InterfacePosition",comment='trackPosition')
 AddGlobal("Vfront",comment='velocity infront of bubble')

--- a/models/multiphase/d3q27_pf_velocity/Dynamics.R
+++ b/models/multiphase/d3q27_pf_velocity/Dynamics.R
@@ -65,14 +65,8 @@ AddStage("calcPhase" , "calcPhaseF",	save="PhaseF", load=DensityAll$group=="h" )
 AddStage("BaseIter"  , "Run"       ,    save=Fields$group %in% c("g","h","Vel","nw"), 
 	                                load=DensityAll$group %in% c("g","h","Vel","nw"))
 
-if (Options$SC) {
-AddStage("WallPhase", "calcWallPhase", save="PhaseF")
-AddAction("Iteration", c("BaseIter", "calcPhase", "WallPhase"))
-AddAction("Init"     , c("PhaseInit", "WallPhase","BaseInit", "calcPhase"))
-} else {
 AddAction("Iteration", c("BaseIter", "calcPhase", "calcWall"))
 AddAction("Init"     , c("PhaseInit","WallInit","calcWall","BaseInit"))
-}
 
 # 	Outputs:
 AddQuantity(name="PhaseField",unit="1")
@@ -93,10 +87,6 @@ AddSetting(name="sigma", 		   comment='surface tension')
 AddSetting(name="ContactAngle", radAngle='ContactAngle*3.1415926535897/180', default='90', comment='Contact angle in degrees')
 AddSetting(name='radAngle', comment='Conversion to rads for calcs')
 
-if (Options$SC) {
-AddSetting(name="ContactAngle", default="90", comment='Contact angle of the phases')
-}
-
 #Domain initialisation (pre-defined set-ups)
 AddSetting(name="RTI_Characteristic_Length", default=-999, comment='Use for RTI instability')
 
@@ -111,13 +101,6 @@ AddSetting(name="tau_l", comment='relaxation time (low density fluid)')
 AddSetting(name="tau_h", comment='relaxation time (high density fluid)')
 AddSetting(name="Viscosity_l", tau_l='(3*Viscosity_l)', default=0.16666666, comment='kinematic viscosity')
 AddSetting(name="Viscosity_h", tau_h='(3*Viscosity_h)', default=0.16666666, comment='kinematic viscosity')
-#AddSetting(name="S0", default=1.0, comment='Relaxation Param')
-#AddSetting(name="S1", default=1.0, comment='Relaxation Param')
-#AddSetting(name="S2", default=1.0, comment='Relaxation Param')
-#AddSetting(name="S3", default=1.0, comment='Relaxation Param')
-#AddSetting(name="S4", default=1.0, comment='Relaxation Param')
-#AddSetting(name="S5", default=1.0, comment='Relaxation Param')
-#AddSetting(name="S6", default=1.0, comment='Relaxation Param')
 #	Inputs: Flow Properties
 AddSetting(name="VelocityX", default=0.0, comment='inlet/outlet/init velocity', zonal=T)
 AddSetting(name="VelocityY", default=0.0, comment='inlet/outlet/init velocity', zonal=T)

--- a/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
+++ b/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
@@ -76,7 +76,6 @@
 #    m25 = 0.5 * U[3,] * (9*absCi2*absCi2 - 33*absCi2+81)
 #    m26 = 0.5 * (9*absCi2*absCi2*absCi2 - 18*absCi2*absCi2 + 87*absCi2 - 26)
 
-
     m23 = 0.5 * U[,1]*(9*absCi2*absCi2 - 33*absCi2 + 26)
     m24 = 0.5 * U[,2]*(9*absCi2*absCi2 - 33*absCi2 + 26)
     m25 = 0.5 * U[,3]*(9*absCi2*absCi2 - 33*absCi2 + 26)
@@ -213,21 +212,6 @@ CudaDeviceFunction void calcWallPhase(){
 		PhaseF = PhaseF(0,0,0);
 	}
 }
-
-#ifdef OPTIONS_SC
-CudaDeviceFunction void calcWallPhase(){
-	PhaseF = PhaseF(0,0,0);
-	if ( Y == 0 ) {
-		if ( ContactAngle == 90 ) {
-			PhaseF = PhaseF(0,1,0);
-		} else {
-			PhaseF = PhaseF(0,1,0) + 0.5 * tan( PI*0.5 - ContactAngle * PI/180.0 ) * sqrt(
-				      ( PhaseF(1,1,0)-PhaseF(-1,1,0) )*( PhaseF(1,1,0)-PhaseF(-1,1,0) )
-				     +( PhaseF(0,1,1)-PhaseF(0,1,-1) )*( PhaseF(0,1,1)-PhaseF(0,1,-1) ) );
-		}
-	}
-}
-#endif
 
 CudaDeviceFunction real_t calcMu(real_t C){
 	real_t pfavg, lpPhi, mu;
@@ -367,6 +351,7 @@ CudaDeviceFunction void Init_distributions(){
 		Gamma[i] = calcGamma(i, U, V, W, mag);
 		if (i < 15) F_phi[i] = calcF_phi(i, tmp1, nx, ny, nz);
 	}
+
 <?R
 	C(h, w_h * phase * gammah - 0.5 * Fphi)
 ?>
@@ -505,7 +490,7 @@ for (j=0;j<2;j++) {
 	C(heq, EQ_h$feq * PV("C"))
 	n = PV("n",c("x","y","z"))
 	EQ_h = MRT_eq(U[1:15,],PV(1),PV(c(0,0,0)))
-	wh = EQ_h$feq
+	wh = c(rep(16/72,1),rep(8/72,6),rep(1/72,8))    #EQ_h$feq
 	C(Fphi, wh * PV("tmp1") * (U[1:15,] %*% n))
 	
 # 	SRT Relaxation for h

--- a/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
+++ b/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
@@ -1,6 +1,7 @@
 <?R
     source("conf.R")
     c_header();
+    source("lib/feq.R")
 ?>
 // 04/02/2017 - Model Developed: A. Fakhari, T. Mitchell
 //    Extension to 3D from:
@@ -482,18 +483,32 @@ CudaDeviceFunction void CollisionMRT(){
 	real_t tau, DynVisc, rho, p;			// Macroscopic Properties
 	vector_t gradPhi;				// Phase field gradients
 	real_t nx, ny, nz, magnPhi;			// Normals
-	real_t Gamma[27], geq[27], mag;			// equilibrium, pressure equilibrium, velocity magnitude
 	real_t F_pressure[3], F_body[3], F_mu[3], F_total[3]; // Forces
 	real_t tmp1, stress[6]={0.0,0.0,0.0,0.0,0.0,0.0};     // Stress tensor calculation
 	real_t F_phi[15], heq[15];			// Phase field collision terms
 	real_t F_i[27];					// Momentum distribution forcing term
-
 	real_t m[27]; //MRT Details
 
 // Find Macroscopic Details
 	mu = calcMu( C );
 	rho = Density_l + (C - PhaseField_l)*(Density_h - Density_l)/(PhaseField_h - PhaseField_l);
-	p = <?R C(sum(g)) ?>;
+	
+	real_t m0[27];
+<?R
+	EQ = MRT_eq(U,PV(1),u,mat=t(M))
+	selR = EQ$order < 10
+	EQ$Req[1] = PV("p")
+	EQ$feq = solve(M) %*% EQ$Req
+	Omega = PV(rep(1,sum(selR)))
+	Omega[5:9] = PV("tau")^(-1)
+	Omega[1:4] = PV(1)
+	m0 = PV("m0[",1:27-1,"]")
+	C(m0[selR], (M %*% g)[selR])
+	F_total = PV("F_total[",1:3-1,"]")
+	rho = PV("rho")
+	rho.inv = rho ^ (-1)
+?>
+	p = m0[0];
 
 // Update tau:
 	if ( C < PhaseField_l){
@@ -532,37 +547,18 @@ CudaDeviceFunction void CollisionMRT(){
 //  	3. and then compile total force - iterate through to update velocity
 //	   and redetermine stress to ensure more accurate F_total
 for (j=0;j<2;j++) {
-//         Determine geq
-	mag = U*U + V*V + W*W;
-	for (i=0; i< 27; i++){
-		Gamma[i] = calcGamma(i, U, V, W, mag);
-		geq[i] = wg[i]*p + Gamma[i] - wg[i];
-	}
-// gi^neq
-<?R	C(geq, g - geq)  ?>
-// MRT Section
-<?R	C(m, M %*% geq)  ?>
-	// Relax Moments:
-		m[4] /= tau;
-		m[5] /= tau;
-		m[6] /= tau;
-		m[7] /= tau;
-		m[8] /= tau;
-<?R	C(geq, invM %*% m)?>
+<?R
+	C(m[selR], (m0 - EQ$Req)[selR] * Omega)
 
-// Stress/strain Tensor
-	for (i=0; i< 6 ; i++)
-	{
-		stress[i] = 0.0;
-	}
-	for (i=0; i< 27; i++){
-		stress[0] += geq[i]*d3q27_ex[i]*d3q27_ex[i];
-		stress[1] += geq[i]*d3q27_ex[i]*d3q27_ey[i];
-		stress[2] += geq[i]*d3q27_ex[i]*d3q27_ez[i];
-		stress[3] += geq[i]*d3q27_ey[i]*d3q27_ey[i];
-		stress[4] += geq[i]*d3q27_ey[i]*d3q27_ez[i];
-		stress[5] += geq[i]*d3q27_ez[i]*d3q27_ez[i];
-	}
+	stress = PV("stress[",1:6-1,"]");
+	new_g = solve(M) %*% m
+	C(stress[1], sum( U[,1]*U[,1] * new_g )); # XX
+	C(stress[2], sum( U[,1]*U[,2] * new_g )); # XY
+	C(stress[3], sum( U[,1]*U[,3] * new_g )); # XZ
+	C(stress[4], sum( U[,2]*U[,2] * new_g )); # YY
+	C(stress[5], sum( U[,2]*U[,3] * new_g )); # YZ
+	C(stress[6], sum( U[,3]*U[,3] * new_g )); # ZZ
+?>
 
 	F_mu[0] = (0.5-tau) * (Density_h-Density_l) * (stress[0]*gradPhi.x + stress[1]*gradPhi.y + stress[2]*gradPhi.z);
 	F_mu[1] = (0.5-tau) * (Density_h-Density_l) * (stress[1]*gradPhi.x + stress[3]*gradPhi.y + stress[4]*gradPhi.z);
@@ -571,39 +567,28 @@ for (j=0;j<2;j++) {
 	F_total[1] = mu*gradPhi.y + F_pressure[1] + F_body[1] + F_mu[1];
 	F_total[2] = mu*gradPhi.z + F_pressure[2] + F_body[2] + F_mu[2];
 
-<?R 	C( u, g %*% U) ?>
-	U = U + (0.5*F_total[0])/rho;
-	V = V + (0.5*F_total[1])/rho;
-	W = W + (0.5*F_total[2])/rho;
+<?R 	C( u, m0[2:4] + 0.5 * F_total * rho.inv) ?>
 }
-
 // PHASE FIELD POPULATION UPDATE:
 	tmp1 = (1.0 - 4.0*(C - 0.5)*(C - 0.5))/IntWidth;
-	for (i=0; i< 15; i++){
-		F_phi[i] = calcF_phi(i, tmp1, nx, ny, nz);
-		heq[i] = C * Gamma[i];
-	}
-// 	SRT Relaxation
 <?R
-	C(h, h - omega * (h - w_h*heq + 0.5*Fphi) + Fphi)
-?>
+	EQ_h = MRT_eq(U[1:15,],PV(1),u)
+	C(heq, EQ_h$feq * PV("C"))
+	n = PV("n",c("x","y","z"))
+	EQ_h = MRT_eq(U[1:15,],PV(1),PV(c(0,0,0)))
+	wh = EQ_h$feq
+	C(Fphi, wh * PV("tmp1") * (U[1:15,] %*% n))
+	
+# 	SRT Relaxation for h
+	C(h, h - omega * (h - heq + 0.5*Fphi) + Fphi)
 
-// PRESSURE EVOLUTION UPDATE:
-	for (i=0; i< 27; i++) {
-		F_i[i] = 3.0*wg[i] * (F_total[0]*d3q27_ex[i] + F_total[1]*d3q27_ey[i] + F_total[2]*d3q27_ez[i])/rho;
-		geq[i] = wg[i]*p + Gamma[i] - wg[i] - 0.5*F_i[i];
-	}
-// 	MRT Relaxation
-<?R 	C(geq, g - geq)
-	C(m, M %*% geq)
-?>
-		m[4] /= tau;
-		m[5] /= tau;
-		m[6] /= tau;
-		m[7] /= tau;
-		m[8] /= tau;
-<?R	C(geq, invM %*% m)
-	C(g, g - geq + Fi)
+
+#	MRT Relaxation for g
+	mF = PV(rep(0,27))
+	mF[2:4] = F_total * rho.inv
+
+	C(m, m0 - (m0 - EQ$Req + mF*0.5)[selR] * Omega + mF)
+	C(g, invM %*% m)
 ?>
 	switch (NodeType & NODE_ADDITIONALS) {
 		real_t location;

--- a/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
+++ b/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
@@ -201,8 +201,8 @@ CudaDeviceFunction void calcWallPhase(){
 		real_t myA, myH, myPhase;
 
 		myPhase = PhaseF_dyn(nw_x, nw_y, nw_z);
-		if (X == 48) printf("Y=%d, %.4f\n",Y,myPhase);
 		myH = 0.5 * sqrt(nw_x*nw_x + nw_y*nw_y + nw_z*nw_z);
+		
 		if ( ContactAngle == 90 ) {
 			PhaseF = myPhase;
 		} else {
@@ -306,14 +306,17 @@ CudaDeviceFunction void Init_wallNorm(){
 
 		<?R
 			myN = PV(paste0("myNorm[",1:3-1,"]"))
-			pf = PV(paste0("PhaseF(",U[,1],",",U[,2],",",U[,3],")"))
+			pf = PV(paste0("PhaseF(",U[,1],",",U[,2],",",U[,3],")/-998"))
 			solid = PV(paste0("solidFlag[",1:27-1,"]"))
-			tmp = PV("1/-998")
 			
-			C(solid, pf*tmp)
-			
-			C(myN, sum(wg*U*solid))
+			C(solid, pf)
 		?>
+		for (i=0;i<27;i++){
+			myNorm[0] += wg[i] * solidFlag[i] * d3q27_ex[i];
+			myNorm[1] += wg[i] * solidFlag[i] * d3q27_ey[i];
+			myNorm[2] += wg[i] * solidFlag[i] * d3q27_ez[i];
+			
+		}
 		myNorm[0] *= -1.0/3.0;
 		myNorm[1] *= -1.0/3.0;
 		myNorm[2] *= -1.0/3.0;

--- a/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
+++ b/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
@@ -25,9 +25,14 @@
 //				  experiment by Bugg et al. (2002)
 //		14/08/2017: Look to improve readability by incorporating more R code
 //				- e.g. for MRT operations etc.
+//		12/12/2017: Model updated for inclusion in v6.2
+//				- MRT collision updated to moment space
+//				- Symmetry bounds removed, autosym added to options
+//				- BGK made option
 
 <?R
     g=PV(DensityAll$name[DensityAll$group=="g"])
+    wg = PV(paste0("wg[",1:27-1,"]"))
 # Extracting velocity set
     U = as.matrix(DensityAll[DensityAll$group=="g",c("dx","dy","dz")])
     u = PV(c("U","V","W"))
@@ -139,47 +144,34 @@ CudaDeviceFunction real_t getP(){
 	return p;
 }
 
+CudaDeviceFunction vector_t getNormal(){
+	vector_t n;
+	n.x = nw_x;
+	n.y = nw_y;
+	n.z = nw_z;
+	return n;
+}
+
 // 	HELPER FUNCTIONS:
 CudaDeviceFunction vector_t calcGradPhi(){
 	vector_t gradPhi = {0.0,0.0,0.0};
-	if ((NodeType & NODE_ADDITIONALS) == NODE_SymmetricXY_W) {
-		gradPhi.x = 16.00 * (PhaseF(1,0,0) - PhaseF(-1,0,0))
-				  	+ 2.0*(PhaseF(1,1,1) - PhaseF(-1,1,1) + PhaseF(1,-1,1) - PhaseF(-1,-1,1))
-		  			+ 4.0 * (PhaseF(1,1,0) - PhaseF(-1,1,0) + PhaseF(1,-1,0) - PhaseF(-1,-1,0)
-			  		      +  PhaseF(1,0,1) - PhaseF(-1,0,1) + PhaseF(1,0,1) - PhaseF(-1,0,1));
-		gradPhi.y = 16.00 * (PhaseF(0,1,0) - PhaseF(0,-1,0))
-		  			+ 2.0*(PhaseF(1,1,1) + PhaseF(-1,1,1) - PhaseF(1,-1,1) - PhaseF(-1,-1,1))
-		  			+ 4.0 * (PhaseF(1,1,0) + PhaseF(-1,1,0) - PhaseF(1,-1,0) - PhaseF(-1,-1,0)
-		          		      +  PhaseF(0,1,1) - PhaseF(0,-1,1) + PhaseF(0,1,1) - PhaseF(0,-1,1));
-		gradPhi.z = 0.0;
-	} else if ((NodeType & NODE_ADDITIONALS) == NODE_SymmetricXY_E) {
-//			printf("Checkpoint2, %d, %d\n", X, Y);
-		gradPhi.x = 16.00 * (PhaseF(1,0,0) - PhaseF(-1,0,0))
-		  			+ 2.0*(PhaseF(1,1,-1) - PhaseF(-1,1,-1) + PhaseF(1,-1,-1) - PhaseF(-1,-1,-1))
-		  			+ 4.0 * (PhaseF(1,1,0) - PhaseF(-1,1,0) + PhaseF(1,-1,0) - PhaseF(-1,-1,0)
-			  		      +  PhaseF(1,0,-1) - PhaseF(-1,0,-1) + PhaseF(1,0,-1) - PhaseF(-1,0,-1));
-		gradPhi.y = 16.00 * (PhaseF(0,1,0) - PhaseF(0,-1,0))
-		  			+ 2.0*(PhaseF(1,1,-1) + PhaseF(-1,1,-1) - PhaseF(1,-1,-1) - PhaseF(-1,-1,-1))
-		  			+ 4.0 * (PhaseF(1,1,0) + PhaseF(-1,1,0) - PhaseF(1,-1,0) - PhaseF(-1,-1,0)
-		          		      +  PhaseF(0,1,-1) - PhaseF(0,-1,-1) + PhaseF(0,1,-1) - PhaseF(0,-1,-1));
-		gradPhi.z = 0.0;
-	} else {
-		gradPhi.x = 16.00 * (PhaseF(1,0,0) - PhaseF(-1,0,0))
-		  			+ PhaseF(1,1,1) - PhaseF(-1,1,1) + PhaseF(1,-1,1) - PhaseF(-1,-1,1)
-		  			+ PhaseF(1,1,-1)- PhaseF(-1,1,-1)+ PhaseF(1,-1,-1)- PhaseF(-1,-1,-1)
-		  			+  4.00 * (PhaseF(1,1,0) - PhaseF(-1,1,0) + PhaseF(1,-1,0) - PhaseF(-1,-1,0)
-			  		+  PhaseF(1,0,1) - PhaseF(-1,0,1) + PhaseF(1,0,-1) - PhaseF(-1,0,-1));
-		gradPhi.y = 16.00 * (PhaseF(0,1,0) - PhaseF(0,-1,0))
-		  			+ PhaseF(1,1,1) + PhaseF(-1,1,1) - PhaseF(1,-1,1) - PhaseF(-1,-1,1)
-		  			+ PhaseF(1,1,-1)+ PhaseF(-1,1,-1)- PhaseF(1,-1,-1)- PhaseF(-1,-1,-1)
-		  			+  4.00 * (PhaseF(1,1,0) + PhaseF(-1,1,0) - PhaseF(1,-1,0) - PhaseF(-1,-1,0)
-		          		+  PhaseF(0,1,1) - PhaseF(0,-1,1) + PhaseF(0,1,-1) - PhaseF(0,-1,-1));
-		gradPhi.z = 16.00 * (PhaseF(0,0,1) - PhaseF(0,0,-1))
-		  			+ PhaseF(1,1,1) + PhaseF(-1,1,1) + PhaseF(1,-1,1) + PhaseF(-1,-1,1)
-		  			- PhaseF(1,1,-1)- PhaseF(-1,1,-1)- PhaseF(1,-1,-1)- PhaseF(-1,-1,-1)
-		  			+  4.00 * (PhaseF(1,0,1) + PhaseF(-1,0,1) - PhaseF(1,0,-1) - PhaseF(-1,0,-1)
-		          		+  PhaseF(0,1,1) + PhaseF(0,-1,1) - PhaseF(0,1,-1) - PhaseF(0,-1,-1));
-	}
+
+	gradPhi.x = 16.00 * (PhaseF(1,0,0) - PhaseF(-1,0,0))
+	  			+ PhaseF(1,1,1) - PhaseF(-1,1,1) + PhaseF(1,-1,1) - PhaseF(-1,-1,1)
+	  			+ PhaseF(1,1,-1)- PhaseF(-1,1,-1)+ PhaseF(1,-1,-1)- PhaseF(-1,-1,-1)
+	  			+  4.00 * (PhaseF(1,1,0) - PhaseF(-1,1,0) + PhaseF(1,-1,0) - PhaseF(-1,-1,0)
+		  		+  PhaseF(1,0,1) - PhaseF(-1,0,1) + PhaseF(1,0,-1) - PhaseF(-1,0,-1));
+	gradPhi.y = 16.00 * (PhaseF(0,1,0) - PhaseF(0,-1,0))
+	  			+ PhaseF(1,1,1) + PhaseF(-1,1,1) - PhaseF(1,-1,1) - PhaseF(-1,-1,1)
+	  			+ PhaseF(1,1,-1)+ PhaseF(-1,1,-1)- PhaseF(1,-1,-1)- PhaseF(-1,-1,-1)
+	  			+  4.00 * (PhaseF(1,1,0) + PhaseF(-1,1,0) - PhaseF(1,-1,0) - PhaseF(-1,-1,0)
+	          		+  PhaseF(0,1,1) - PhaseF(0,-1,1) + PhaseF(0,1,-1) - PhaseF(0,-1,-1));
+	gradPhi.z = 16.00 * (PhaseF(0,0,1) - PhaseF(0,0,-1))
+	  			+ PhaseF(1,1,1) + PhaseF(-1,1,1) + PhaseF(1,-1,1) + PhaseF(-1,-1,1)
+	  			- PhaseF(1,1,-1)- PhaseF(-1,1,-1)- PhaseF(1,-1,-1)- PhaseF(-1,-1,-1)
+	  			+  4.00 * (PhaseF(1,0,1) + PhaseF(-1,0,1) - PhaseF(1,0,-1) - PhaseF(-1,0,-1)
+	          		+  PhaseF(0,1,1) + PhaseF(0,-1,1) - PhaseF(0,1,-1) - PhaseF(0,-1,-1));
+	
 	gradPhi.x /= 72.0;
 	gradPhi.y /= 72.0;
 	gradPhi.z /= 72.0;
@@ -187,15 +179,39 @@ CudaDeviceFunction vector_t calcGradPhi(){
 }
 
 CudaDeviceFunction void calcPhaseF(){
-if ((NodeType & NODE_ADDITIONALS) == NODE_SymmetricXY_W) {
-	PhaseF = h0+h1+h2+h3+h4+2.0*(h6+h11+h12+h13+h14);
-} else if ((NodeType & NODE_ADDITIONALS) == NODE_SymmetricXY_E) {
-	PhaseF = h0+h1+h2+h3+h4+2.0*(h5+h7+h8+h9+h10);
-} else if ((NodeType & NODE_BOUNDARY) == NODE_Wall) {
-	PhaseF = PhaseField;
-} else {
+    switch (NodeType & NODE_BOUNDARY) {
+		case NODE_Solid:
+		case NODE_Wall:
+			BounceBack();
+			break;
+		case NODE_MovingWall_N:
+			MovingNWall();
+			break;
+		case NODE_MovingWall_S:
+			MovingSWall();
+			break;
+	}
+
 	PhaseF = <?R C(sum(h))?>;
+
 }
+
+CudaDeviceFunction void calcWallPhase(){
+	if ((NodeType & NODE_BOUNDARY) == NODE_Wall) {
+		real_t myA, myH, myPhase;
+
+		myPhase = PhaseF_dyn(nw_x, nw_y, nw_z);
+		if (X == 48) printf("Y=%d, %.4f\n",Y,myPhase);
+		myH = 0.5 * sqrt(nw_x*nw_x + nw_y*nw_y + nw_z*nw_z);
+		if ( ContactAngle == 90 ) {
+			PhaseF = myPhase;
+		} else {
+			myA = 1.0 - myH * (4.0/IntWidth) * cos(radAngle);
+			PhaseF = ( myA - sqrt( myA*myA - 4.0*(myA - 1.0)*myPhase) )/(myA-1.0) - myPhase; 
+		}
+	} else {
+		PhaseF = PhaseF(0,0,0);
+	}
 }
 
 #ifdef OPTIONS_SC
@@ -217,37 +233,6 @@ CudaDeviceFunction real_t calcMu(real_t C){
 	real_t pfavg, lpPhi, mu;
 	pfavg = 0.5*(PhaseField_l+PhaseField_h);
 
-if ((NodeType & NODE_ADDITIONALS) == NODE_SymmetricXY_W) {
-	lpPhi = 16.0 *((PhaseF(1,0,0)) + (PhaseF(-1,0,0))
-        	     + (PhaseF(0,1,0)) + (PhaseF(0,-1,0))
-        	     + (PhaseF(0,0,1)) + (PhaseF(0,0,1)))
-       	       + 1.0 *((PhaseF(1,1,1)) + (PhaseF(-1,1,1))
-       		     + (PhaseF(1,-1,1))+ (PhaseF(-1,-1,1))
-             	     + (PhaseF(1,1,1))+ (PhaseF(-1,1,1))
-                     + (PhaseF(1,-1,1))+(PhaseF(-1,-1,1)))
-       	       + 4.0 *((PhaseF(1,1,0)) + (PhaseF(-1,1,0))
-	     	     + (PhaseF(1,-1,0))+ (PhaseF(-1,-1,0))
-	             + (PhaseF(1,0,1)) + (PhaseF(-1,0,1))
-	             + (PhaseF(1,0,1))+ (PhaseF(-1,0,1))
-	             + (PhaseF(0,1,1)) + (PhaseF(0,-1,1))
-	             + (PhaseF(0,1,1))+ (PhaseF(0,-1,1)))
-	       - 152.0 * PhaseF(0,0,0);
-} else if ((NodeType & NODE_ADDITIONALS) == NODE_SymmetricXY_E) {
-	lpPhi = 16.0 *((PhaseF(1,0,0)) + (PhaseF(-1,0,0))
-        	     + (PhaseF(0,1,0)) + (PhaseF(0,-1,0))
-        	     + (PhaseF(0,0,-1)) + (PhaseF(0,0,-1)))
-       	       + 1.0 *((PhaseF(1,1,-1)) + (PhaseF(-1,1,-1))
-       		     + (PhaseF(1,-1,-1))+ (PhaseF(-1,-1,-1))
-             	     + (PhaseF(1,1,-1))+ (PhaseF(-1,1,-1))
-                     + (PhaseF(1,-1,-1))+(PhaseF(-1,-1,-1)))
-       	       + 4.0 *((PhaseF(1,1,0)) + (PhaseF(-1,1,0))
-	     	     + (PhaseF(1,-1,0))+ (PhaseF(-1,-1,0))
-	             + (PhaseF(1,0,-1)) + (PhaseF(-1,0,-1))
-	             + (PhaseF(1,0,-1))+ (PhaseF(-1,0,-1))
-	             + (PhaseF(0,1,-1)) + (PhaseF(0,-1,-1))
-	             + (PhaseF(0,1,-1))+ (PhaseF(0,-1,-1)))
-	       - 152.0 * PhaseF(0,0,0);
-} else {
 	lpPhi = 16.0 *((PhaseF(1,0,0)) + (PhaseF(-1,0,0))
         	     + (PhaseF(0,1,0)) + (PhaseF(0,-1,0))
         	     + (PhaseF(0,0,1)) + (PhaseF(0,0,-1)))
@@ -262,7 +247,7 @@ if ((NodeType & NODE_ADDITIONALS) == NODE_SymmetricXY_W) {
 	             + (PhaseF(0,1,1)) + (PhaseF(0,-1,1))
 	             + (PhaseF(0,1,-1))+ (PhaseF(0,-1,-1)))
 	       - 152.0 * PhaseF(0,0,0);
-}
+
 	lpPhi /= 36.0;
 
 	mu = 4.0*(12.0*sigma/IntWidth)*(C-PhaseField_l)*(C-PhaseField_h)*(C-pfavg)
@@ -307,19 +292,60 @@ CudaDeviceFunction void Init() {
 			PhaseF = 1.0;
 		}
 	}
+	if ((NodeType & NODE_BOUNDARY) == NODE_Wall) {
+		PhaseF = -999;
+	}
+
+}
+
+CudaDeviceFunction void Init_wallNorm(){
+	if ((NodeType & NODE_BOUNDARY) == NODE_Wall) {
+		int solidFlag[27], i, maxi;
+		real_t myNorm[3] = {0.0,0.0,0.0};
+		real_t maxn=0.0, dot;
+
+		<?R
+			myN = PV(paste0("myNorm[",1:3-1,"]"))
+			pf = PV(paste0("PhaseF(",U[,1],",",U[,2],",",U[,3],")"))
+			solid = PV(paste0("solidFlag[",1:27-1,"]"))
+			tmp = PV("1/-998")
+			
+			C(solid, pf*tmp)
+			
+			C(myN, sum(wg*U*solid))
+		?>
+		myNorm[0] *= -1.0/3.0;
+		myNorm[1] *= -1.0/3.0;
+		myNorm[2] *= -1.0/3.0;
+		
+		real_t tmp;
+		tmp = myNorm[0]*myNorm[0] + myNorm[1]*myNorm[1] + myNorm[2]*myNorm[2];
+		for (i = 0; i<27; i++) {
+			dot = (myNorm[0]*d3q27_ex[i] + myNorm[1]*d3q27_ey[i] + myNorm[2]*d3q27_ez[i]) /
+			      sqrt( tmp*(d3q27_ex[i]*d3q27_ex[i] + d3q27_ey[i]*d3q27_ey[i] + 
+					 d3q27_ez[i]*d3q27_ez[i]) + 1e-12);
+			if (dot > maxn) {
+				maxn = dot;
+				maxi = i;
+			}
+		nw_x = d3q27_ex[maxi];
+		nw_y = d3q27_ey[maxi];
+		nw_z = d3q27_ez[maxi];
+		}
+	} else {
+		nw_x = 0.0;
+		nw_y = 0.0;
+		nw_z = 0.0;
+	}
 }
 
 CudaDeviceFunction void Init_distributions(){
 // Find Gradients and normals:
 	int i;
 	real_t C;
-if ((NodeType & NODE_ADDITIONALS) == NODE_SymmetricXY_W) {
-	C = PhaseF(0,0,1);
-} else if ((NodeType & NODE_ADDITIONALS) == NODE_SymmetricXY_E) {
-	C = PhaseF(0,0,-1);
-} else {
+
 	C = PhaseF(0,0,0);
-}
+
 	real_t C0 = 0.5*(PhaseField_h - PhaseField_l);
 	vector_t gradPhi = calcGradPhi();
 	real_t nx, ny, nz, magnPhi;
@@ -351,14 +377,6 @@ if ((NodeType & NODE_ADDITIONALS) == NODE_SymmetricXY_W) {
 
 //	ITERATION:
 CudaDeviceFunction void Run() {
-// SYMMETRY BOUNDARIES ARE NOT YET TESTED!!
-// If you test / fix their implementation before m, then let me know :P
-    switch (NodeType & NODE_ADDITIONALS) {
-		case NODE_SymmetricXY_W:
-			SymmetryXY_W();
-		case NODE_SymmetricXY_E:
-			SymmetryXY_E();
-    }
     switch (NodeType & NODE_BOUNDARY) {
 		case NODE_Solid:
 		case NODE_Wall:
@@ -371,112 +389,20 @@ CudaDeviceFunction void Run() {
 			MovingSWall();
 			break;
 	}
+
+#ifdef OPTIONS_BGK
+    if (NodeType & NODE_BGK) {
+		CollisionBGK();
+    }
+#else
     if (NodeType & NODE_MRT)
     {
 		CollisionMRT();
-    } else if (NodeType & NODE_BGK) {
-		CollisionBGK();
-	}
+    } 
+#endif
 }
 
-CudaDeviceFunction void CollisionBGK(){
-	int i, j;
-	real_t C = PhaseF(0,0,0), mu;
-	real_t tau, DynVisc, rho, p;			// Macroscopic Properties
-	vector_t gradPhi;				// Phase field gradients
-	real_t nx, ny, nz, magnPhi;			// Normals
-	real_t Gamma[27], geq[27], mag;			// equilibrium, pressure equilibrium, velocity magnitude
-	real_t F_pressure[3], F_body[3], F_mu[3], F_total[3]; // Forces
-	real_t tmp1, stress[6]={0.0,0.0,0.0,0.0,0.0,0.0};     // Stress tensor calculation
-	real_t F_phi[15], heq[15];			// Phase field collision terms
-	real_t F_i[27];					// Momentum distribution forcing term
-
-// Find Macroscopic Details
-	mu = calcMu( C );
-	rho = Density_l + (C - PhaseField_l)*(Density_h - Density_l)/(PhaseField_h - PhaseField_l);
-	p = <?R C(sum(g)) ?>;
-
-// Update tau:
-	if ( C < PhaseField_l){
-		tau = tau_l + 0.5;
-	} else if (C > PhaseField_h) {
-		tau = tau_h + 0.5;
-	} else {
-		tau = 0.5 + tau_l + (C-PhaseField_l)*(tau_h - tau_l)/(PhaseField_h - PhaseField_l);
-	}
-
-// GRADIENTS AND NORMALS
-	gradPhi = calcGradPhi();
-	magnPhi = sqrt(gradPhi.x*gradPhi.x + gradPhi.y*gradPhi.y + gradPhi.z*gradPhi.z + 1e-32);
-	nx = gradPhi.x/magnPhi;
-	ny = gradPhi.y/magnPhi;
-	nz = gradPhi.z/magnPhi;
-
-// CALCULATE FORCES:
-	F_pressure[0] = (-1.0/3.0) * p * (Density_h-Density_l) * gradPhi.x;
-	F_pressure[1] = (-1.0/3.0) * p * (Density_h-Density_l) * gradPhi.y;
-	F_pressure[2] = (-1.0/3.0) * p * (Density_h-Density_l) * gradPhi.z;
-	F_body[0] = (rho-Density_h)*BuoyancyX + rho*GravitationX;
-	F_body[1] = (rho-Density_h)*BuoyancyY + rho*GravitationY;
-	F_body[2] = (rho-Density_h)*BuoyancyZ + rho*GravitationZ;
-
-// VISCOUS FORCE:
-for (j=0;j<2;j++) {
-// GAMMA AND EQUILIBRIUM
-	mag = U*U + V*V + W*W;
-	for (i=0; i< 27; i++){
-		Gamma[i] = calcGamma(i, U, V, W, mag);
-		geq[i] = wg[i]*p + Gamma[i] - wg[i];
-	}
-
-<?R 	C( geq, g - geq ) ?>
-		// Stress/strain Tensor
-	for (i=0; i< 6 ; i++)
-	{
-		stress[i] = 0.0;
-	}
-	for (i=0; i< 27; i++){
-		stress[0] += geq[i]*d3q27_ex[i]*d3q27_ex[i];
-		stress[1] += geq[i]*d3q27_ex[i]*d3q27_ey[i];
-		stress[2] += geq[i]*d3q27_ex[i]*d3q27_ez[i];
-		stress[3] += geq[i]*d3q27_ey[i]*d3q27_ey[i];
-		stress[4] += geq[i]*d3q27_ey[i]*d3q27_ez[i];
-		stress[5] += geq[i]*d3q27_ez[i]*d3q27_ez[i];
-	}
-
-	F_mu[0] = (0.5-tau)/tau * (Density_h-Density_l) * (stress[0]*gradPhi.x + stress[1]*gradPhi.y + stress[2]*gradPhi.z);
-	F_mu[1] = (0.5-tau)/tau * (Density_h-Density_l) * (stress[1]*gradPhi.x + stress[3]*gradPhi.y + stress[4]*gradPhi.z);
-	F_mu[2] = (0.5-tau)/tau * (Density_h-Density_l) * (stress[2]*gradPhi.x + stress[4]*gradPhi.y + stress[5]*gradPhi.z);
-	F_total[0] = mu*gradPhi.x + F_pressure[0] + F_body[0] + F_mu[0];
-	F_total[1] = mu*gradPhi.y + F_pressure[1] + F_body[1] + F_mu[1];
-	F_total[2] = mu*gradPhi.z + F_pressure[2] + F_body[2] + F_mu[2];
-
-<?R C( u, g %*% U) ?>
-	U = U + (0.5*F_total[0])/rho;
-	V = V + (0.5*F_total[1])/rho;
-	W = W + (0.5*F_total[2])/rho;
-}
-
-// PHASE FIELD POPULATION UPDATE:
-	tmp1 = (1.0 - 4.0*(C - 0.5)*(C - 0.5))/IntWidth;
-	for (i=0; i< 15; i++){
-		F_phi[i] = calcF_phi(i, tmp1, nx, ny, nz); 		// Forcing Terms
-		heq[i] = C * Gamma[i];      	// heq
-	}
-
-<?R	C(h, h - omega * ( h - w_h*heq + 0.5*Fphi) + Fphi) ?>
-
-// PRESSURE EVOLUTION UPDATE:
-	for (i=0; i< 27; i++) {
-		F_i[i] = 3.0*wg[i] * (F_total[0]*d3q27_ex[i] + F_total[1]*d3q27_ey[i] + F_total[2]*d3q27_ez[i])/rho;
-	}
-real_t omega_g = 1.0/tau;
-<?R	om= PV("omega_g")
-
-	C(g, g - (geq+0.5*Fi)*om + Fi)
-?>
-}
-
+#ifndef OPTIONS_BGK
 CudaDeviceFunction void CollisionMRT(){
 	int i, j;
 	real_t C = PhaseF(0,0,0), mu;
@@ -487,7 +413,7 @@ CudaDeviceFunction void CollisionMRT(){
 	real_t tmp1, stress[6]={0.0,0.0,0.0,0.0,0.0,0.0};     // Stress tensor calculation
 	real_t F_phi[15], heq[15];			// Phase field collision terms
 	real_t F_i[27];					// Momentum distribution forcing term
-	real_t m[27]; //MRT Details
+	real_t m[27]; 					//MRT Details
 
 // Find Macroscopic Details
 	mu = calcMu( C );
@@ -623,51 +549,9 @@ for (j=0;j<2;j++) {
 			}
 	}
 }
+#endif
+
 //	BOUNDARY CONDITIONS:
-CudaDeviceFunction void SymmetryXY_W()
-{
-	g5  = g6; //  (001 - 002)
-
-	g7  = g11; // (111 - 112)
-	g8  = g12; // (211 - 212)
-	g9  = g13; // (121 - 122)
-	g10 = g14; // (221 - 222)
-
-	g19 = g21; // (101 - 102)
-	g20 = g22; // (201 - 202)
-	g23 = g25; // (011 - 012)
-	g24 = g26; // (021 - 022)
-
-	h5  = h6;
-
-	h7  = h11;
-	h8  = h12;
-	h9  = h13;
-	h10 = h14;
-}
-
-CudaDeviceFunction void SymmetryXY_E()
-{
-	g6  = g5 ;
-
-	g14 = g10;
-	g13 = g9 ;
-	g12 = g8 ;
-	g11 = g7 ;
-
-	g22 = g20;
-	g21 = g19;
-	g26 = g24;
-	g25 = g23;
-
-	h6  = h5 ;
-
-	h14 = h10;
-	h13 = h9 ;
-	h12 = h8 ; 
-	h11 = h7 ;
-}
-
 CudaDeviceFunction void MovingNWall()
 {
 	g4  = g3;
@@ -753,3 +637,103 @@ CudaDeviceFunction float2 Color() {
         }
         return ret;
 }
+
+#ifdef OPTIONS_BGK
+CudaDeviceFunction void CollisionBGK(){
+	int i, j;
+	real_t C = PhaseF(0,0,0), mu;
+	real_t tau, DynVisc, rho, p;			// Macroscopic Properties
+	vector_t gradPhi;				// Phase field gradients
+	real_t nx, ny, nz, magnPhi;			// Normals
+	real_t Gamma[27], geq[27], mag;			// equilibrium, pressure equilibrium, velocity magnitude
+	real_t F_pressure[3], F_body[3], F_mu[3], F_total[3]; // Forces
+	real_t tmp1, stress[6]={0.0,0.0,0.0,0.0,0.0,0.0};     // Stress tensor calculation
+	real_t F_phi[15], heq[15];			// Phase field collision terms
+	real_t F_i[27];					// Momentum distribution forcing term
+
+// Find Macroscopic Details
+	mu = calcMu( C );
+	rho = Density_l + (C - PhaseField_l)*(Density_h - Density_l)/(PhaseField_h - PhaseField_l);
+	p = <?R C(sum(g)) ?>;
+
+// Update tau:
+	if ( C < PhaseField_l){
+		tau = tau_l + 0.5;
+	} else if (C > PhaseField_h) {
+		tau = tau_h + 0.5;
+	} else {
+		tau = 0.5 + tau_l + (C-PhaseField_l)*(tau_h - tau_l)/(PhaseField_h - PhaseField_l);
+	}
+
+// GRADIENTS AND NORMALS
+	gradPhi = calcGradPhi();
+	magnPhi = sqrt(gradPhi.x*gradPhi.x + gradPhi.y*gradPhi.y + gradPhi.z*gradPhi.z + 1e-32);
+	nx = gradPhi.x/magnPhi;
+	ny = gradPhi.y/magnPhi;
+	nz = gradPhi.z/magnPhi;
+
+// CALCULATE FORCES:
+	F_pressure[0] = (-1.0/3.0) * p * (Density_h-Density_l) * gradPhi.x;
+	F_pressure[1] = (-1.0/3.0) * p * (Density_h-Density_l) * gradPhi.y;
+	F_pressure[2] = (-1.0/3.0) * p * (Density_h-Density_l) * gradPhi.z;
+	F_body[0] = (rho-Density_h)*BuoyancyX + rho*GravitationX;
+	F_body[1] = (rho-Density_h)*BuoyancyY + rho*GravitationY;
+	F_body[2] = (rho-Density_h)*BuoyancyZ + rho*GravitationZ;
+
+// VISCOUS FORCE:
+for (j=0;j<2;j++) {
+// GAMMA AND EQUILIBRIUM
+	mag = U*U + V*V + W*W;
+	for (i=0; i< 27; i++){
+		Gamma[i] = calcGamma(i, U, V, W, mag);
+		geq[i] = wg[i]*p + Gamma[i] - wg[i];
+	}
+
+<?R 	C( geq, g - geq ) ?>
+		// Stress/strain Tensor
+	for (i=0; i< 6 ; i++)
+	{
+		stress[i] = 0.0;
+	}
+	for (i=0; i< 27; i++){
+		stress[0] += geq[i]*d3q27_ex[i]*d3q27_ex[i];
+		stress[1] += geq[i]*d3q27_ex[i]*d3q27_ey[i];
+		stress[2] += geq[i]*d3q27_ex[i]*d3q27_ez[i];
+		stress[3] += geq[i]*d3q27_ey[i]*d3q27_ey[i];
+		stress[4] += geq[i]*d3q27_ey[i]*d3q27_ez[i];
+		stress[5] += geq[i]*d3q27_ez[i]*d3q27_ez[i];
+	}
+
+	F_mu[0] = (0.5-tau)/tau * (Density_h-Density_l) * (stress[0]*gradPhi.x + stress[1]*gradPhi.y + stress[2]*gradPhi.z);
+	F_mu[1] = (0.5-tau)/tau * (Density_h-Density_l) * (stress[1]*gradPhi.x + stress[3]*gradPhi.y + stress[4]*gradPhi.z);
+	F_mu[2] = (0.5-tau)/tau * (Density_h-Density_l) * (stress[2]*gradPhi.x + stress[4]*gradPhi.y + stress[5]*gradPhi.z);
+	F_total[0] = mu*gradPhi.x + F_pressure[0] + F_body[0] + F_mu[0];
+	F_total[1] = mu*gradPhi.y + F_pressure[1] + F_body[1] + F_mu[1];
+	F_total[2] = mu*gradPhi.z + F_pressure[2] + F_body[2] + F_mu[2];
+
+<?R C( u, g %*% U) ?>
+	U = U + (0.5*F_total[0])/rho;
+	V = V + (0.5*F_total[1])/rho;
+	W = W + (0.5*F_total[2])/rho;
+}
+
+// PHASE FIELD POPULATION UPDATE:
+	tmp1 = (1.0 - 4.0*(C - 0.5)*(C - 0.5))/IntWidth;
+	for (i=0; i< 15; i++){
+		F_phi[i] = calcF_phi(i, tmp1, nx, ny, nz); 		// Forcing Terms
+		heq[i] = C * Gamma[i];      	// heq
+	}
+
+<?R	C(h, h - omega * ( h - w_h*heq + 0.5*Fphi) + Fphi) ?>
+
+// PRESSURE EVOLUTION UPDATE:
+	for (i=0; i< 27; i++) {
+		F_i[i] = 3.0*wg[i] * (F_total[0]*d3q27_ex[i] + F_total[1]*d3q27_ey[i] + F_total[2]*d3q27_ez[i])/rho;
+	}
+real_t omega_g = 1.0/tau;
+<?R	om= PV("omega_g")
+
+	C(g, g - (geq+0.5*Fi)*om + Fi)
+?>
+}
+#endif

--- a/models/multiphase/d3q27_pf_velocity/conf.mk
+++ b/models/multiphase/d3q27_pf_velocity/conf.mk
@@ -1,6 +1,6 @@
 ADJOINT=0
 TEST=FALSE
-OPT="SC"
+OPT="(SC+BGK)*autosym"
 # SC: Solid Contact
 # 	This option currently fixes the bottom layer of nodes to be 
 # 	solid with the contact angle defined in input.

--- a/models/multiphase/d3q27_pf_velocity/conf.mk
+++ b/models/multiphase/d3q27_pf_velocity/conf.mk
@@ -1,6 +1,6 @@
 ADJOINT=0
 TEST=FALSE
-OPT="(SC+BGK)*autosym"
+OPT="(BGK)*autosym"
 # SC: Solid Contact
 # 	This option currently fixes the bottom layer of nodes to be 
 # 	solid with the contact angle defined in input.

--- a/models/optimization/d2q9_adj/Dynamics.R
+++ b/models/optimization/d2q9_adj/Dynamics.R
@@ -38,3 +38,5 @@ AddSetting(name="PorocityTheta", comment='theta in hiperbolic transformation of 
 AddSetting(name="Porocity", comment='initial porocity of Porous nodes', zonal=TRUE)
 
 #AddNodeType(name="MovingWall", group="BOUNDARY")
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/models/optimization/d3q19_adj/Dynamics.R
+++ b/models/optimization/d3q19_adj/Dynamics.R
@@ -153,3 +153,6 @@ AddGlobal(name="EnergyFlux", comment='pressure loss')
 AddGlobal(name="PressureFlux", comment='pressure loss')
 AddGlobal(name="PressureDiff", comment='pressure loss')
 AddGlobal(name="MaterialPenalty", comment='quadratic penalty for intermediate material parameter')
+
+AddNodeType("Inlet","OBJECTIVE")
+AddNodeType("Outlet","OBJECTIVE")

--- a/src/Consts.h.Rt
+++ b/src/Consts.h.Rt
@@ -23,11 +23,21 @@
 #endif
 
 <?R
+  big_hex = function(x,bits=16) {
+    ret = ""
+    while (x > 0 | bits > 0) {
+      a = x %% 16
+      ret = sprintf("%01x%s",a,ret)
+      x = (x-a) / 16
+      bits = bits - 4
+    }
+    ret
+  }
   for (n in names(Node)) { ?>
-#define NODE_<?%-20s n ?> 0x<?%08x Node[n] ?> <?R
+#define NODE_<?%-20s n ?> 0x<?%s big_hex(Node[n]) ?> <?R
   }
   for (n in names(Node_Group)) { ?>
-#define NODE_<?%-20s n ?> 0x<?%08x Node_Group[n] ?> <?R
+#define NODE_<?%-20s n ?> 0x<?%s big_hex(Node_Group[n]) ?> <?R
   }
 ?>
 <?R

--- a/src/LatticeAccess.inc.cpp.Rt
+++ b/src/LatticeAccess.inc.cpp.Rt
@@ -350,22 +350,33 @@ CudaDeviceFunction real_t LatticeContainer::load_<?%s f$nicename ?>  (const int 
 
 <?R
 if (Options$autosym) {
-  sym_load = function(f,d,i) {
-   if (i > 3) { ?>
+  sym_load = function(f,d,i,sig=1) {
+   if (i > 3) {
+    if (sig < 0) { ?>
+    return -load0_<?%s f$nicename ?> < <?%d d[1] ?>, <?%d d[2] ?>, <?%d d[3] ?> > (x,y,z,nt);
+<?R } else { ?>
     return load0_<?%s f$nicename ?> < <?%d d[1] ?>, <?%d d[2] ?>, <?%d d[3] ?> > (x,y,z,nt);
-   <?R } else {
+<?R }
+   } else {
     s = names(symmetries)[i]
-    si = which(Fields$name == f[[s]])
+    fn = f[[s]]
+    if (substr(fn,1,1) == "-") {
+     nsig = -1;
+     fn = substr(fn,2,nchar(fn))
+    } else {
+     nsig = 1;
+    }
+    si = which(Fields$name == fn)
     sf = rows(Fields)[[si]]
     sd = d
     sd[i] = -sd[i]
     ch = c("X","Y","Z")[i]
     if (d[i] > 0) { ?>
-    if ((nt & NODE_SYM<?%s ch ?>) == NODE_Symmetry<?%s ch ?>_plus) { <?R sym_load(sf,sd,i+1) ?> }
+    if ((nt & NODE_SYM<?%s ch ?>) == NODE_Symmetry<?%s ch ?>_plus) { <?R sym_load(sf,sd,i+1,sig*nsig) ?> }
     <?R } else if (d[i] < 0) { ?>
-    if ((nt & NODE_SYM<?%s ch ?>) == NODE_Symmetry<?%s ch ?>_minus) { <?R sym_load(sf,sd,i+1) ?> }
+    if ((nt & NODE_SYM<?%s ch ?>) == NODE_Symmetry<?%s ch ?>_minus) { <?R sym_load(sf,sd,i+1,sig*nsig) ?> }
     <?R } ?>
-    <?R sym_load(f,d,i+1)
+    <?R sym_load(f,d,i+1,sig)
     }
   }
 

--- a/src/conf.R
+++ b/src/conf.R
@@ -302,13 +302,13 @@ AddNodeType("EVelocity","BOUNDARY")
 # AddNodeType("Wet","ADDITIONALS")
 # AddNodeType("Dry","ADDITIONALS")
 # AddNodeType("Propagate","ADDITIONALS")
-AddNodeType("Inlet","OBJECTIVE")
-AddNodeType("Outlet","OBJECTIVE")
+#AddNodeType("Inlet","OBJECTIVE")
+#AddNodeType("Outlet","OBJECTIVE")
 # AddNodeType("Obj1","OBJECTIVE")
 # AddNodeType("Obj2","OBJECTIVE")
 # AddNodeType("Obj3","OBJECTIVE")
 # AddNodeType("Thermometer","OBJECTIVE")
-AddNodeType("DesignSpace","DESIGNSPACE")
+#AddNodeType("DesignSpace","DESIGNSPACE")
 
 Stages=NULL
 
@@ -398,12 +398,16 @@ if (Options$autosym) { ## Automatic symmetries
     for (d in rows(D)) {
       v = c(d$dx,d$dy,d$dz)
       for (s in names(symmetries)) if (d[[s]] == "") {
-        s_v = v * symmetries[,s]
-        s_sel = (D$dx == s_v[1]) & (D$dy == s_v[2]) & (D$dz == s_v[3])
-        if (sum(s_sel) == 0) stop("Could not find symmetry for density",d$name)
-        if (sum(s_sel) > 1) stop("Too many symmetries for density",d$name)
-        i = which(s_sel)
-        s_d = D[s_sel,,drop=FALSE]
+	if (all(v == 0)) {
+		s_d = d
+	} else {
+          s_v = v * symmetries[,s]
+          s_sel = (D$dx == s_v[1]) & (D$dy == s_v[2]) & (D$dz == s_v[3])
+          if (sum(s_sel) == 0) stop("Could not find symmetry for density",d$name)
+          if (sum(s_sel) > 1) stop("Too many symmetries for density",d$name)
+          i = which(s_sel)
+          s_d = D[s_sel,,drop=FALSE]
+	}
         DensityAll[DensityAll$name == d$name,s] = s_d$name
         if (Fields[Fields$name == d$field,s] == "") Fields[Fields$name == d$field,s] = s_d$field
       }
@@ -412,7 +416,7 @@ if (Options$autosym) { ## Automatic symmetries
 
   for (s in names(symmetries)) {
     sel = Fields[,s] == ""
-    Fields[sel,s] = Fields$name[s]
+    Fields[sel,s] = Fields$name[sel]
   }
 
   AddNodeType("SymmetryX_plus",  group="SYMX")

--- a/src/conf.R
+++ b/src/conf.R
@@ -308,7 +308,7 @@ AddNodeType("EVelocity","BOUNDARY")
 # AddNodeType("Obj2","OBJECTIVE")
 # AddNodeType("Obj3","OBJECTIVE")
 # AddNodeType("Thermometer","OBJECTIVE")
-#AddNodeType("DesignSpace","DESIGNSPACE")
+AddNodeType("DesignSpace","DESIGNSPACE")
 
 Stages=NULL
 
@@ -488,13 +488,15 @@ NodeTypes = do.call(rbind, by(NodeTypes,NodeTypes$group,function(tab) {
 	tab
 }))
 FlagT = "unsigned short int"
+FlagTBits = 16
 if (NodeShiftNum > 14) {
 	FlagT = "unsigned int"
+	FlagTBits = 32
 	if (NodeShiftNum > 30) {
 		stop("NodeTypes exceeds 32 bits")
 	}
 }
-ZoneBits = 16 - NodeShiftNum
+ZoneBits = FlagTBits - NodeShiftNum
 ZoneShift = NodeShiftNum
 if (ZoneBits == 0) warning("No additional zones! (too many node types) - it will run, but you cannot use local settings")
 ZoneMax = 2^ZoneBits
@@ -507,10 +509,10 @@ NodeTypes = rbind(NodeTypes,data.frame(
         mask=(ZoneMax-1)*NodeShift,
         shift=NodeShiftNum
 ))
-NodeShiftNum = 16
+NodeShiftNum = FlagTBits
 NodeShift = 2^NodeShiftNum
 
-if (any(NodeTypes$value >= 2^16)) stop("NodeTypes exceeds short int")
+if (any(NodeTypes$value >= 2^FlagTBits)) stop("NodeTypes exceeds short int")
 
 NodeTypes = rbind(NodeTypes, data.frame(
 	name="None",

--- a/src/conf.R
+++ b/src/conf.R
@@ -487,36 +487,28 @@ NodeTypes = do.call(rbind, by(NodeTypes,NodeTypes$group,function(tab) {
 	NodeShiftNum <<- NodeShiftNum + l
 	tab
 }))
-
-if (NodeShiftNum > 16) {
-	stop("NodeTypes exceeds short int")
-} else {
-	ZoneBits = 16 - NodeShiftNum
-	ZoneShift = NodeShiftNum
-	if (ZoneBits == 0) warning("No additional zones! (too many node types) - it will run, but you cannot use local settings")
-	ZoneMax = 2^ZoneBits
-#	ZoneRange = 1:ZoneMax
-#	NodeTypes = rbind(NodeTypes,data.frame(
-#		name=paste("SettingZone",ZoneRange,sep=""),
-#		group="SETTINGZONE",
-#		index=ZoneRange,
-#		Index=paste("SettingZone",ZoneRange,sep=""),
-#		value=(ZoneRange-1)*NodeShift,
-#		mask=(ZoneMax-1)*NodeShift,
-#		shift=NodeShiftNum
-#	))
-	NodeTypes = rbind(NodeTypes,data.frame(
-		name="DefaultZone",
-		group="SETTINGZONE",
-		index=1,
-		Index="DefaultZone",
-		value=0,
-		mask=(ZoneMax-1)*NodeShift,
-		shift=NodeShiftNum
-	))
-	NodeShiftNum = 16
-	NodeShift = 2^NodeShiftNum
+FlagT = "unsigned short int"
+if (NodeShiftNum > 14) {
+	FlagT = "unsigned int"
+	if (NodeShiftNum > 30) {
+		stop("NodeTypes exceeds 32 bits")
+	}
 }
+ZoneBits = 16 - NodeShiftNum
+ZoneShift = NodeShiftNum
+if (ZoneBits == 0) warning("No additional zones! (too many node types) - it will run, but you cannot use local settings")
+ZoneMax = 2^ZoneBits
+NodeTypes = rbind(NodeTypes,data.frame(
+        name="DefaultZone",
+        group="SETTINGZONE",
+        index=1,
+        Index="DefaultZone",
+        value=0,
+        mask=(ZoneMax-1)*NodeShift,
+        shift=NodeShiftNum
+))
+NodeShiftNum = 16
+NodeShift = 2^NodeShiftNum
 
 if (any(NodeTypes$value >= 2^16)) stop("NodeTypes exceeds short int")
 

--- a/src/cuda.cu.Rt
+++ b/src/cuda.cu.Rt
@@ -50,9 +50,9 @@ CudaDeviceFunction CudaConstantMemory real_t <?%s v$name ?> = 0.0f; <?R
         }
 ?>
 
-#define X (x_ + constContainer.px)
-#define Y (y_ + constContainer.py)
-#define Z (z_ + constContainer.pz)
+#define X ((real_t) x_ + constContainer.px + 0.5)
+#define Y ((real_t) y_ + constContainer.py + 0.5)
+#define Z ((real_t) z_ + constContainer.pz + 0.5)
 #define Time (constContainer.iter)
 #define SyntheticTurbulence(x__,y__,z__) constContainer.getST(x__,y__,z__)
 #define average_iter (constContainer.iter - constContainer.reset_iter)  //Look nicer in Dynamics

--- a/src/def.cpp.Rt
+++ b/src/def.cpp.Rt
@@ -23,7 +23,7 @@ const char* xml_definition = "<Geometry>\
 	<Zone name='Tunnel'> <Box dx='0' dy='0' dz='0' fx='0' fy='-1' fz='-1'/></Zone>\
 	<Zone name='Inlet'><Box dx='0' dy='0' dz='0' fx='0' fy='-1' fz='-1'/></Zone>\
 <?R for (i in 1:length(Node_Group)) {
-?>	<Mask name='<?%s names(Node_Group)[i]?>' value='<?%d Node_Group[i]?>'/>\
+?>	<Mask name='<?%s names(Node_Group)[i]?>' value='<?%f Node_Group[i]?>'/>\
 <?R }
     for (i in 1:length(Node)) { x = Node_Group; x = x[x >= Node[i]];
 ?>	<Type name='<?%s names(Node)[i]?>' value='<?%d Node[i]?>' mask='<?%s names(x)[which.min(x)]?>'/>\

--- a/src/types.h.Rt
+++ b/src/types.h.Rt
@@ -1,3 +1,4 @@
+<?R source("conf.R") ?>
 #ifndef TYPES_H
   #define TYPES_H
 
@@ -11,7 +12,7 @@
 //  typedef struct {real_t x,y,z;} vector_t_b;
 
 //  typedef char flag_t;
-  typedef unsigned short int flag_t;
+  typedef <?%s FlagT ?> flag_t;
 
   typedef unsigned char cut_t;
   

--- a/src/vtkOutput.h
+++ b/src/vtkOutput.h
@@ -36,7 +36,7 @@ public:
 	inline void WriteField(char * name, unsigned char * data) { WriteField(name, (void*) data, sizeof(char), "UInt8", 1); };
 	inline void WriteField(char * name, short int * data) { WriteField(name, (void*) data, sizeof(short int), "Int16", 1); };
 	inline void WriteField(char * name, unsigned short int * data) { WriteField(name, (void*) data, sizeof(unsigned short int), "UInt16", 1); };
-	inline void WriteField(char * name, unsigned int * data) { WriteField(name, (void*) data, sizeof(unsigned short int), "UInt32", 1); };
+	inline void WriteField(char * name, unsigned int * data) { WriteField(name, (void*) data, sizeof(unsigned int), "UInt32", 1); };
 	void Finish();
 	void Close();
 };

--- a/src/vtkOutput.h
+++ b/src/vtkOutput.h
@@ -36,6 +36,7 @@ public:
 	inline void WriteField(char * name, unsigned char * data) { WriteField(name, (void*) data, sizeof(char), "UInt8", 1); };
 	inline void WriteField(char * name, short int * data) { WriteField(name, (void*) data, sizeof(short int), "Int16", 1); };
 	inline void WriteField(char * name, unsigned short int * data) { WriteField(name, (void*) data, sizeof(unsigned short int), "UInt16", 1); };
+	inline void WriteField(char * name, unsigned int * data) { WriteField(name, (void*) data, sizeof(unsigned short int), "UInt32", 1); };
 	void Finish();
 	void Close();
 };


### PR DESCRIPTION
I have implemented three-phase contact interactions to the d3q27_pf_velocity model (variable contact angle). Also used to test autosymmetries in v6.2 as per the three examples added. The BGK option for collision type in this model has also been moved to an option and the MRT collision kernel written by Lucas has been used.
