### PR TITLE
[V6.2 RC] Switching to dynamic strategy for load of Fields with big stencil

### DIFF
--- a/src/LatticeAccess.inc.cpp.Rt
+++ b/src/LatticeAccess.inc.cpp.Rt
@@ -297,6 +297,7 @@ suffix = ""
 if (Options$autosym) suffix = "0"
 
     for (f in rows(Fields)) {
+    if (! f$big) {
     for (dz in f$minz:f$maxz) {
     for (dy in f$miny:f$maxy) {
     for (dx in f$minx:f$maxx) { ?>
@@ -310,12 +311,7 @@ CudaDeviceFunction real_t LatticeContainer::load<?%s suffix ?>_<?%s f$nicename ?
   con=load.field("ret", f, p, dp, con) ?>
   return ret;
 }
-
-
-
-<?R } ?>
-<?R } ?>
-<?R } ?>
+<?R }}} ?>
 
 template <int DY, int DZ> 
 CudaDeviceFunction real_t LatticeContainer::load_<?%s f$nicename ?> (const int & x, const int & y, const int & z, const flag_t & nt, const int & dx) 
@@ -346,7 +342,22 @@ CudaDeviceFunction real_t LatticeContainer::load_<?%s f$nicename ?>  (const int 
     default: return NAN;
   }
 }
-<?R } ?>
+<?R } else { ?>
+CudaDeviceFunction real_t LatticeContainer::load_<?%s f$nicename ?>  (const int & x, const int & y, const int & z, const flag_t & nt, const int & dx, const int & dy, const int & dz) 
+{
+  real_t ret; <?R
+  con = make.context("in");
+  p = PV(c("x","y","z"));
+  dp = PV(c("dx","dy","dz"));
+  con=load.field("ret", f, p, dp, con) ?>
+  return ret;
+}
+
+
+<?R
+    } 
+    }
+?>
 
 <?R
 if (Options$autosym) {

--- a/src/LatticeContainer.h.Rt
+++ b/src/LatticeContainer.h.Rt
@@ -74,7 +74,8 @@ class LatticeContainer {
   template<class N>  CudaDeviceFunction void getType(N & f);
 
 //  template <class N> CudaDeviceFunction void pop_new(N & node); <?R
-  for (f in rows(Fields)) { ?>
+  for (f in rows(Fields)) {
+    if (! f$big) { ?>
   template <int DX, int DY, int DZ>
   CudaDeviceFunction real_t load_<?%s f$nicename ?> (const int & x, const int & y, const int & z, const flag_t & nt) {
     typename Cannot_stream_the_field_in_the_direction_<DX,DY,DZ>::Field_name_<?%s f$nicename ?> Hej;
@@ -88,7 +89,13 @@ class LatticeContainer {
   template <int DZ>
   CudaDeviceFunction real_t load_<?%s f$nicename ?> (const int & x, const int & y, const int & z, const flag_t & nt, const int & dx, const int & dy);
   CudaDeviceFunction real_t load_<?%s f$nicename ?> (const int & x, const int & y, const int & z, const flag_t & nt, const int & dx, const int & dy, const int & dz);
-  <?R
+  <?R } else { ?>
+  CudaDeviceFunction real_t load_<?%s f$nicename ?> (const int & x, const int & y, const int & z, const flag_t & nt, const int & dx, const int & dy, const int & dz);
+  template <int DX, int DY, int DZ>
+  CudaDeviceFunction real_t load_<?%s f$nicename ?> (const int & x, const int & y, const int & z, const flag_t & nt) {
+    return load_<?%s f$nicename ?>(x,y,z,nt,DX,DY,DZ);
+  };
+  <?R }
   } ?>
 //  template <class N> CudaDeviceFunction void push_new(N & node);
 


### PR DESCRIPTION
For fields that are accessed in more then 27 places, LatticeAccess will switch to fully dynamic access of the fields, cutting on the number of template specializations and the final kernel size.