### PR TITLE
gcc 7 compilation errors

### DIFF
--- a/src/Handlers/MainContainer.cpp
+++ b/src/Handlers/MainContainer.cpp
@@ -4,7 +4,7 @@ std::string MainContainer::xmlname = "CLBConfig";
 
 int MainContainer::Init () {
 		GenericAction::Init();
-		char filename[STRING_LEN];
+		char filename[2*STRING_LEN];
 
 		solver->outIterFile("config", ".xml", filename);
 		pugi::xml_node n = solver->configfile.child("CLBConfig").append_child("Run");

--- a/src/Handlers/cbDumpSettings.cpp
+++ b/src/Handlers/cbDumpSettings.cpp
@@ -13,7 +13,7 @@ int cbDumpSettings::Init () {
 
 int cbDumpSettings::DoIt () {
 		Callback::DoIt();
-		char fn[STRING_LEN];
+		char fn[2*STRING_LEN];
 		solver->outIterFile(filename.c_str(), ".csv", fn);
 		solver->lattice->zSet.dumpToFile(fn);
 		return 0;

--- a/src/Handlers/cbLog.cpp
+++ b/src/Handlers/cbLog.cpp
@@ -3,7 +3,7 @@ std::string cbLog::xmlname = "Log";
 #include "../HandlerFactory.h"
 
 int cbLog::Init () {
-		char fn[STRING_LEN];
+		char fn[2*STRING_LEN];
 		Callback::Init();
 		pugi::xml_attribute attr = node.attribute("name");
 		std::string nm = "Log";

--- a/src/Handlers/cbSample.cpp
+++ b/src/Handlers/cbSample.cpp
@@ -4,7 +4,7 @@ std::string cbSample::xmlname = "Sample";
 
 int cbSample::Init () {
 		std::string nm="Sampler";
-		char fn[STRING_LEN];
+		char fn[2*STRING_LEN];
 		Callback::Init();
 		if (everyIter == 0) {
                 	error("Iteration value in sampler should not be zero");

--- a/src/Handlers/cbSaveBinary.cpp
+++ b/src/Handlers/cbSaveBinary.cpp
@@ -8,7 +8,7 @@ int cbSaveBinary::Init () {
 		if (!attr) {
 			attr = node.attribute("filename");
 			if (!attr) {
-				char filename[STRING_LEN];
+				char filename[2*STRING_LEN];
 				solver->outIterFile("Save", "", filename);
 				fn = filename;
 			} else {

--- a/src/Handlers/cbSaveMemoryDump.cpp
+++ b/src/Handlers/cbSaveMemoryDump.cpp
@@ -8,7 +8,7 @@ int cbSaveMemoryDump::Init () {
 		if (!attr) {
 			attr = node.attribute("filename");
 			if (!attr) {
-				char filename[STRING_LEN];
+				char filename[2*STRING_LEN];
 				solver->outIterFile("Save", "", filename);
 				fn = filename;
 			} else {

--- a/src/Lattice.cu.Rt
+++ b/src/Lattice.cu.Rt
@@ -193,7 +193,7 @@ void Lattice::startRecord()
 		iSnaps[i]= -1;
 	}
 	{
-		char filename[STRING_LEN];
+		char filename[2*STRING_LEN];
 		sprintf(filename, "%s_%02d_%02d.dat", snapFileName, D_MPI_RANK, getSnap(0));
 		iSnaps[getSnap(0)] = 0;
 		save(Snaps[Snap], filename);
@@ -738,7 +738,7 @@ void Lattice::IterateTill(int it, int iter_type)
 	if (imx >= nSnaps) {
 		if (reverse_save) {
 			debug2("Reverse Adjoint Disk Read it:%d level:%d\n", mx, imx);
-			char filename[STRING_LEN];
+			char filename[2*STRING_LEN];
 			sprintf(filename, "%s_%02d_%02d.dat", snapFileName, D_MPI_RANK, imx);
 			if (load(Snaps[0], filename)) exit(-1);
 		} else {
@@ -761,7 +761,7 @@ void Lattice::IterateTill(int it, int iter_type)
 		if (s2 >= nSnaps){
 			if (reverse_save) {
 				debug2("Reverse Adjoint Disk Write it:%d level:%d\n", i+1, s2);
-				char filename[STRING_LEN];
+				char filename[2*STRING_LEN];
 				sprintf(filename, "%s_%02d_%02d.dat", snapFileName, D_MPI_RANK, s2);
 				save(Snaps[0], filename);
 			}

--- a/src/Solver.cpp.Rt
+++ b/src/Solver.cpp.Rt
@@ -218,7 +218,7 @@ void MainFree( Solver *d);
 */
 	int Solver::writeVTK(const char * nm, name_set * s) {
 		print("writing vtk");
-		char filename[STRING_LEN];
+		char filename[2*STRING_LEN];
 		outIterFile(nm, ".vti", filename);
 		int ret = vtkWriteLattice(filename, lattice, units, s);
 		return ret;
@@ -233,7 +233,7 @@ void MainFree( Solver *d);
 */
 	int Solver::writeTXT(const char * nm, name_set * s, int type) {
 		print("writing txt");
-		char filename[STRING_LEN];
+		char filename[2*STRING_LEN];
 		outIterFile(nm, "", filename);
 		int ret = txtWriteLattice(filename, lattice, units, s, type);
 		return ret;
@@ -248,7 +248,7 @@ void MainFree( Solver *d);
 */
 	int Solver::writeBIN(const char * nm) {
 		print("writing bin");
-		char filename[STRING_LEN];
+		char filename[2*STRING_LEN];
 		outIterFile(nm, "", filename);
 		int ret = binWriteLattice(filename, lattice, units);
 		return ret;


### PR DESCRIPTION
fix note: ‘__builtin___sprintf_chk’ output between X and X bytes into…a destination of size 1024 warnings in gcc7

```
The -Wformat-overflow=level option detects certain and likely buffer overflow in calls to the sprintf family of formatted output functions. Although the option is enabled even without optimization it works best with -O2 and higher.

For example, in the following snippet the call to sprintf is diagnosed because even though its output has been constrained using the modulo operation it could result in as many as three bytes if mday were negative. The solution is to either allocate a larger buffer or make sure the argument is not negative, for example by changing mday's type to unsigned or by making the type of the second operand of the modulo expression unsigned: 100U.

void* f (int mday)
{
  char *buf = malloc (3);
  sprintf (buf, "%02i", mday % 100);
  return buf;
}

warning: 'sprintf may write a terminating nul past the end of the destination [-Wformat-overflow=]
note: 'sprintf' output between 3 and 4 bytes into a destination of size 3
```
see: https://gcc.gnu.org/gcc-7/changes.html