### PR TITLE
Stop XML execution if error occurred (non-zero handler exit status)

### DIFF
--- a/src/Handlers/GenericAction.cpp
+++ b/src/Handlers/GenericAction.cpp
@@ -23,7 +23,10 @@ int GenericAction::ExecuteInternal () {
 						solver->hands.push_back(hand);
 						stack++;
 					} else {
-						hand.DoIt();
+						if ( 0 != hand.DoIt() ) {
+                            error("Handler call error: %s", par.name());
+                            return -1;
+                        };
 					}
 				}
 			} else return -1;


### PR DESCRIPTION
Return value of the handler must be handled somehow.
