### PR TITLE
Fixed bug in ADmod.R

### DIFF
--- a/src/Handlers/acObjective.cpp.Rt
+++ b/src/Handlers/acObjective.cpp.Rt
@@ -9,9 +9,10 @@ std::string acObjective::xmlname = "Objective";
 
 int acObjective::Init () {
 	int zone_number = 0;
-	double * glob = solver->lattice->globals;
+	double glob[ GLOBALS ];
+	for (size_t i = 0; i < GLOBALS; i++) glob[i] = solver->lattice->globals[i];
+	MPI_Bcast(glob, GLOBALS, MPI_DOUBLE, 0, solver->mpi_comm);
 	pugi::xml_attribute attr;
-//	solver->lattice->calcGlobals();
 <?R
 	for (g in rows(Globals)) if (! g$adjoint) { ?>
 	#define <?%s g$name ?> glob[<?%s g$Index ?>] <?R
@@ -40,9 +41,11 @@ int acObjective::Init () {
                 i = which(ZoneSettings$name == paste(c,"InObj",sep=""));
                 s = ZoneSettings[i,,drop=FALSE];
 ?>
+	output("<?%s s$Index?> in zone_number = %lg\n", <?%s c ?>InObj);
         solver->lattice->zSet.set(<?%s s$Index?>, zone_number, <?%s c ?>InObj); <?R
         }
 ?>
+	solver->lattice->globals[ GLOBALS_Objective ] = Objective;
 		return 0;
 	}
 

--- a/tools/ADmod.R
+++ b/tools/ADmod.R
@@ -31,7 +31,7 @@ b = sapply(bracer,function(x){sum(x>0)})
 a = cumsum(a-b)
 
 a[a>1]=1
-begins = which(diff(a)==1)+2
+begins = which(diff(a)==1)+1
 
 f = file(opt$out)
 open(f,"wt")


### PR DESCRIPTION
The bug was causing the ADmod script to skip first line in all functions (this bug should have not affected previous adjoint builds, as it caused compilation error.