### PR TITLE
Adding the ray_axis selection to STL import

### DIFF
--- a/doc/elements.yaml
+++ b/doc/elements.yaml
@@ -220,11 +220,21 @@ STL:
   attr:
     - name: file
       val: file
-    - side:
-      - out
-      - in
-      - surface
-
+      comment: STL file to import
+    - name: side
+      val:
+        select:
+        - out
+        - in
+        - surface
+      comment: Specifies if to fill the interior (in), exterior (out), or the surface (see description)
+    - name: ray_axis
+      val:
+        select:
+        - x
+        - y
+        - z
+      comment: Specifies the axis along which rays will be cast for in/out filling of STL
 Params:
   type:
     params

--- a/doc/elements.yaml
+++ b/doc/elements.yaml
@@ -216,6 +216,12 @@ Wedge:
         - BottomRight
 
 STL:
+  comment: >
+    Imports a STL file as geometrical object. The element works in two modes.
+    In the first mode, it fills elements inside or outside of the STL geometry (casting rays along some axis).
+    In the second mode (`side="surface"`) it fills elements touching the geometry (on both sides) and
+    **calculates the cuts* for Interpolated-BounceBack-type conditions.
+  example: <STL file="geometry.stl" scale="1m" x="10" side="out"/>
   type: geom
   attr:
     - name: file
@@ -235,6 +241,10 @@ STL:
         - y
         - z
       comment: Specifies the axis along which rays will be cast for in/out filling of STL
+    - name: scale
+      val:
+        unit: float
+      comment: Specifies the scale by which the STL geometry should be multiplied. If you work in physical units, this can be e.g. "1m"
 Params:
   type:
     params

--- a/src/Geometry.cpp.Rt
+++ b/src/Geometry.cpp.Rt
@@ -499,6 +499,7 @@ inline int Geometry::loadSTL(lbRegion reg, pugi::xml_node n)
     int ntri;
     int ret;
     int insideOut=0;
+    int axis = 1;
     if (!n.attribute("file")) {
 	error("No 'file' attribute in 'STL' element in xml conf\n");
 	return -1;
@@ -513,6 +514,23 @@ inline int Geometry::loadSTL(lbRegion reg, pugi::xml_node n)
             insideOut=2;
         } else {
 	    error("'side' in 'STL' element have to be 'in', 'out' or 'surface'\n");
+	    return -1;
+	}
+    }
+    if (n.attribute("ray_axis")) {
+	if (insideOut > 1) {
+		error("the 'ray_axis' setting in 'STL' makes sens only with 'in' or 'out' side\n");
+		return -1;
+	}
+        std::string ray_axis=n.attribute("ray_axis").value();
+        if (ray_axis == "x") {
+	    axis=0;
+        } else if (ray_axis == "y") {
+            axis=1;
+        } else if (ray_axis == "z") {
+            axis=2;
+        } else {
+	    error("'ray_axis' in 'STL' element have to be 'x', 'y' or 'z'\n");
 	    return -1;
 	}
     }
@@ -555,12 +573,6 @@ inline int Geometry::loadSTL(lbRegion reg, pugi::xml_node n)
 		min[j] -= 1;
 		max[j] += 1;
 	}
-	double v[2], v1[2], v2[2], c0, c1, c2, c3;
-	v1[0] = tri[i].p2[0] - tri[i].p1[0];
-	v1[1] = tri[i].p2[2] - tri[i].p1[2];
-	v2[0] = tri[i].p3[0] - tri[i].p1[0];
-	v2[1] = tri[i].p3[2] - tri[i].p1[2];
-	c0 = v1[0] * v2[1] - v1[1] * v2[0];
 	if (insideOut == 2) {
             size_t regsize = region.sizeL();
             for (int x = min[0]; x <= max[0]; x++)
@@ -578,21 +590,38 @@ inline int Geometry::loadSTL(lbRegion reg, pugi::xml_node n)
                             }
                     }
 	} else {
-            for (int x = min[0]; x <= max[0]; x++)
-                for (int z = min[2]; z <= max[2]; z++) {
-                    v[0] = x - tri[i].p1[0];
-                    v[1] = z - tri[i].p1[2];
+		int ax1 = axis;
+		int ax2 = (axis+1) % 3;
+		int ax3 = (axis+2) % 3;
+		int lx1 = 0;
+		if (ax1 == 0) lx1 = reg.dx;
+		if (ax1 == 1) lx1 = reg.dy;
+		if (ax1 == 2) lx1 = reg.dz;
+		double v[2], v1[2], v2[2], c0, c1, c2, c3;
+		v1[0] = tri[i].p2[ax2] - tri[i].p1[ax2];
+		v1[1] = tri[i].p2[ax3] - tri[i].p1[ax3];
+		v2[0] = tri[i].p3[ax2] - tri[i].p1[ax2];
+		v2[1] = tri[i].p3[ax3] - tri[i].p1[ax3];
+		c0 = v1[0] * v2[1] - v1[1] * v2[0];
+            for (int x2 = min[ax2]; x2 <= max[ax2]; x2++)
+                for (int x3 = min[ax3]; x3 <= max[ax3]; x3++) {
+                    v[0] = x2 - tri[i].p1[ax2];
+                    v[1] = x3 - tri[i].p1[ax3];
                     c1 = v1[0] * v[1] - v1[1] * v[0];
                     c2 = v[0] * v2[1] - v[1] * v2[0];
                     c1 /= c0;
                     c2 /= c0;
                     if ((c1 >= 0) && (c2 >= 0) && (c1 + c2 <= 1)) {
                         c3 = 1. - c1 - c2;
-                        double h = tri[i].p1[1] * c3 + tri[i].p2[1] * c2 + tri[i].p3[1] * c1;
-                        for (int y = reg.dy; y <= h; y++) {
+                        double h = tri[i].p1[ax1] * c3 + tri[i].p2[ax1] * c2 + tri[i].p3[ax1] * c1;
+                        for (int x1 = lx1; x1 <= h; x1++) {
     //                                        debug1("%d %d %d %d\n",x,y,z,reg.offset(x,y,z));
-                            if (reg.isIn(x, y, z))
-                                lev[reg.offset(x, y, z)]++;
+				int x,y,z;
+				if (axis == 0) { x = x1; y = x2; z = x3; }
+				if (axis == 1) { x = x3; y = x1; z = x2; }
+				if (axis == 2) { x = x2; y = x3; z = x1; }
+	                        if (reg.isIn(x, y, z))
+        	                        lev[reg.offset(x, y, z)]++;
                         }
                     }
                 }


### PR DESCRIPTION
Adding support for changing the axis along with the rays are shot to import STL in the `in`/`out` mode.

## Example:
This will fill elements with `Wall` boundary condition outside of a STL:
```xml
<Wall mask="ALL">
<STL file="file.stl" side="out" ray_axis="x"/>
</Wall>
```
but by selecting the x `ray_axis`, the elements will be marked for filling starting from x=0, and in the direction of growing x. This makes difference **if stl file is not closed** or is aligned a way it would make it hard to cast rays along other axis.
