### PR TITLE
Change of naming of the ESYS-Particle integration element

### DIFF
--- a/example/particle/2d/chain.xml
+++ b/example/particle/2d/chain.xml
@@ -14,7 +14,7 @@
 		<Params VelocityX="0.025"/>
 		<Params Viscosity="0.01"/>
 		<Params GravitationX="-0.00"/>
-		<RemoteForceInterface Iterations="100000" particle="NRotSphere" periodic="x">
+		<ESYSParticle Iterations="100000" particle="NRotSphere" periodic="x">
 import random
 from math import pi
 R=32
@@ -58,7 +58,7 @@ bondGrp = sim.createInteractionGroup(
 )
 
 sim.setParticleNonDynamic(2)
-		</RemoteForceInterface>
+		</ESYSParticle>
 	</Model>
 	<VTK Iterations="100"/>
 	<Solve Iterations="100000"/>

--- a/src/Handlers/acESYSParticle.cpp
+++ b/src/Handlers/acESYSParticle.cpp
@@ -1,0 +1,223 @@
+#include "acESYSParticle.h"
+std::string acESYSParticle::xmlname = "ESYSParticle";
+#include "../HandlerFactory.h"
+
+
+int acESYSParticle::Init () {
+        Action::Init();
+        bool need_file = true;
+        MPMDIntercomm inter_;
+        pugi::xml_attribute attr;
+        char fn[STRING_LEN];
+        std::string filename;
+        int N;
+        double units[3];
+        units[0] = solver->units.alt("1m");
+        units[1] = solver->units.alt("1s");
+        units[2] = solver->units.alt("1kg");
+
+        printf("uni:%d - world:%d\n",MPMD.universe_size, MPMD.world_size);
+        N = MPMD.universe_size - MPMD.world_size;
+
+        inter_ = MPMD["ESYSPARTICLE"];
+        if (inter_) need_file = false;
+
+        if (need_file) {
+                attr = node.attribute("script");
+                if (attr) {
+                        sprintf(fn,"%s",attr.value());
+                        filename = attr.value();
+                        need_file = false;
+                }
+        }
+        if (need_file) {
+                xcirc = false;
+                ycirc = false; //JM
+                zcirc = false; //JM
+                particle_type = "NRotSphere";
+                sim = "sim";
+                gridSpacing = 25.0;
+                verletDist = 5.0;
+                double sx,sy,sz; // Size of the domain for ESYS
+                attr = node.attribute("particle");
+                if (attr) particle_type = attr.value();
+                if (particle_type == "NRotSphere") {
+                } else if (particle_type == "RotSphere") {
+                } else {
+                        ERROR("Unknown particle type in ESYS\n");
+                        return -1;
+                }
+                attr = node.attribute("gridSpacing");
+                if (attr) gridSpacing = attr.as_double();
+                attr = node.attribute("verletDist");
+                if (attr) verletDist = attr.as_double();
+                attr = node.attribute("esys-object");
+                if (attr) sim = attr.value();
+                
+                /*
+                attr = node.attribute("periodic");
+                if (attr) {
+                        if (strcmp(attr.value(),"x") == 0) {
+                                xcirc = true;
+                        } else if (strcmp(attr.value(),"") == 0) {
+                                xcirc = false;
+                        } else {
+                                ERROR("ESYS-Particles can be only periodic in X direction\n");
+                                return -1;
+                        }
+                } */
+                //JM Version for full periodicity
+                attr = node.attribute("periodic");
+                if (attr) {
+                        if (strcmp(attr.value(),"x") == 0) {
+                                xcirc = true;
+                        } else if (strcmp(attr.value(),"y") == 0) {
+                                ycirc = true;
+                        } else if (strcmp(attr.value(),"z") == 0) {
+                                zcirc = true;
+                        } else if (strcmp(attr.value(),"x+y") == 0) {
+                                xcirc = true;
+                                ycirc = true;
+                        } else if (strcmp(attr.value(),"x+z") == 0) {
+                                xcirc = true;
+                                zcirc = true;
+                        } else if (strcmp(attr.value(),"y+z") == 0) {
+                                ycirc = true;
+                                zcirc = true;
+                        } else if (strcmp(attr.value(),"x+y+z") == 0) {
+                                xcirc = true;
+                                ycirc = true;
+                                zcirc = true;
+                        } else if (strcmp(attr.value(),"") == 0) {
+                                xcirc = false;
+                                ycirc = false;
+                                zcirc = false;
+                        } else {
+                                ERROR("Incorrect input options use e.g. x+y\n");
+                                return -1;
+                        }
+                }
+                        
+                sx = solver->mpi.totalregion.nx;
+                sy = solver->mpi.totalregion.ny;
+                sz = solver->mpi.totalregion.nz;
+                
+                int workers = N - 1;
+                if (workers < 1) {
+                        ERROR("ESYS-P: No place for workers (you need at least 2 additionals processes)\n");
+                        return -1;
+                }
+                int nx=1, ny=1, nz=1;
+                {
+                        int nx0, ny0, nz0;
+                        int tot, tot1;
+                        
+                        //JM 
+                        int xper, yper, zper;
+                        xper = xcirc ? 1 : 0;
+                        yper = ycirc ? 1 : 0;
+                        zper = zcirc ? 1 : 0;                        
+                        
+                        tot=0;
+                        nx0 = solver->mpi.divx;
+                        ny0 = solver->mpi.divy;
+                        nz0 = solver->mpi.divz;
+                        if (nx0 <= xper) nx0 = xper + 1;
+                        if (ny0 <= yper) ny0 = yper + 1;
+                        if (nz0 <= zper) nz0 = zper + 1;
+                        output("%dx%dx%d\n",nx0, ny0, nz0);
+                        //JM *per additions to account for periodicity in multiple directions (hopefully ...)
+                        for (int nx1=1; nx1<=nx0; nx1++) if (nx0 % nx1 == 0) {
+                                for (int ny1=1; ny1<=ny0; ny1++) if (ny0 % ny1 == 0) {
+                                        for (int nz1=1; nz1<=nz0; nz1++) if (nz0 % nz1 == 0) {
+                                                int tot1 = nx1*ny1*nz1;
+                                                if (tot1 <= workers) {
+                                                        if (workers % tot1 == 0) {
+                                                                int nx_ = workers / (ny1 * nz1);
+                                                                if ((nx_ > xper) && (ny1 > yper) && (nz1 > zper)) {
+                                                                        if (tot1 > tot) {
+                                                                                tot = tot1;
+                                                                                nx = workers / (ny1 * nz1);
+                                                                                ny = ny1;
+                                                                                nz = nz1;
+                                                                        }
+                                                                }
+                                                        }
+                                                }
+                                        }
+                                }
+                        }
+                        if (tot == 0) {
+                                output("Error may be due to periodicity in multiple directions calculation");
+                                ERROR("ESYS-P: Cannot find a good division. Requested workers (%d) do not fit well with TCLB division (%dx%dx%d)\n", workers, nx0, ny0, nz0);
+                                return -1;
+                        }
+                }
+                output("ESYS-P: Will be running at %dx%dx%d\n", nx, ny, nz);
+
+                if (xcirc) {
+                        if (nx < 2) {
+                                ERROR("ESYS-P can be periodic in X only when there are 2 processes in this direction.\n");
+                                return -1;
+                        }
+                }
+                //JM
+                if (ycirc) {
+                        if (ny < 2) {
+                                ERROR("ESYS-P can be periodic in Y only when there are 2 processes in this direction.\n");
+                                return -1;
+                        }
+                }
+                if (zcirc) {
+                        if (nz < 2) {
+                                ERROR("ESYS-P can be periodic in Z only when there are 2 processes in this direction.\n");
+                                return -1;
+                        }
+                }
+
+                double maxRad = 10;
+
+        //	solver->outGlobalFile("ESYS", ".py", fn);
+                sprintf(fn, "%s_%s.py", solver->info.outpath, "ESYS");
+                output("ESYS-P: config: %s\n", fn);
+                if (D_MPI_RANK == 0) {
+                        FILE * f = fopen(fn, "wt");
+                        fprintf(f, "from esys.lsm import *\n");
+                        fprintf(f, "from esys.lsm.util import Vec3, BoundingBox\n");
+                        fprintf(f, "from esys.lsm.geometry import *\n\n");
+                        fprintf(f, "%s = LsmMpi(numWorkerProcesses=%d, mpiDimList=[%d,%d,%d])\n", sim.c_str(), nx*ny*nz, nx, ny, nz);
+                        fprintf(f, "%s.initNeighbourSearch( particleType=\"%s\", gridSpacing=%lg, verletDist=%lg )\n", sim.c_str(), particle_type.c_str(), gridSpacing, verletDist);
+                        fprintf(f, "%s.setSpatialDomain( BoundingBox(Vec3(%lg,%lg,%lg), Vec3(%lg,%lg,%lg)), circDimList = [%s, %s, %s])\n", //JM [%s,False, False]
+                                sim.c_str(),
+                                0.0, 0.0, 0.0,
+                                sx/units[0], sy/units[0], sz/units[0],
+                                xcirc ? "True" : "False",
+                                ycirc ? "True" : "False",
+                                zcirc ? "True" : "False");
+                        fprintf(f, "%s.setTimeStepSize(%lg)\n", sim.c_str(), 1.0/units[1]);
+                        fprintf(f, "%s.setNumTimeSteps(%d)\n", sim.c_str(), Next(solver->iter));
+                        fprintf(f, "%s.createInteractionGroup(	RemoteForcePrms(name=\"tclb\", remote_name=\"%s\", max_rad=%lg) )\n", sim.c_str(), MPMD.name.c_str(), maxRad);
+                        fprintf(f, "output_prefix=\"%s_%s\"\n", solver->info.outpath, "ESYS");
+                        fprintf(f, "def output_path(x):\n\treturn output_prefix + x\n");
+                        fprintf(f, "%s\n", node.child_value());
+                        fprintf(f, "%s.run()\n", sim.c_str());
+                        fflush(f);
+                        fclose(f);
+                }
+
+        }
+        MPI_Barrier(MPMD.local);
+
+        char * args[] = {fn,NULL};
+        
+        if (! inter_) {
+                output("Spawning esysparticle with script: %s\n", fn);
+                inter_ = MPMD.Spawn("esysparticle", args, N, MPI_INFO_NULL);
+        }
+        acRemoteForceInterface::ConnectRemoteForceInterface("ESYSPARTICLE");
+	return 0;
+}
+
+
+// Register the handler (basing on xmlname) in the Handler Factory
+template class HandlerFactory::Register< GenericAsk< acESYSParticle > >;

--- a/src/Handlers/acESYSParticle.h
+++ b/src/Handlers/acESYSParticle.h
@@ -1,0 +1,23 @@
+#ifndef ACESYSPARTICLE_H
+#define ACESYSPARTICLE_H
+
+#include "../CommonHandler.h"
+
+#include "vHandler.h"
+#include "Action.h"
+#include "acRemoteForceInterface.h"
+
+class  acESYSParticle  : public acRemoteForceInterface  {
+	public:
+	static std::string xmlname;
+	std::string particle_type;
+	std::string sim;
+	double gridSpacing;
+	double verletDist;
+	bool xcirc;
+	bool ycirc; //JM
+	bool zcirc; //JM
+	int Init ();
+};
+
+#endif // ACESYSPARTICLE_H

--- a/src/Handlers/acRemoteForceInterface.cpp
+++ b/src/Handlers/acRemoteForceInterface.cpp
@@ -12,6 +12,7 @@ int acRemoteForceInterface::Init () {
 
 
 int acRemoteForceInterface::ConnectRemoteForceInterface(std::string integrator_) {
+        output("Connecting RFI to %s\n",integrator_.c_str());
         pugi::xml_attribute attr;
         double units[3];
         units[0] = solver->units.alt("1m");
@@ -23,7 +24,7 @@ int acRemoteForceInterface::ConnectRemoteForceInterface(std::string integrator_)
 
         inter = MPMD[integrator_];
         if (! inter) {
-                ERROR("Integrator %s not found in MPMD (that usualy means that you didn't run it)\n");
+                ERROR("Integrator %s not found in MPMD (that usualy means that you didn't run it)\n",integrator_.c_str());
                 return -1;
         }
         integrator = integrator_;

--- a/src/Handlers/acRemoteForceInterface.cpp
+++ b/src/Handlers/acRemoteForceInterface.cpp
@@ -2,223 +2,35 @@
 std::string acRemoteForceInterface::xmlname = "RemoteForceInterface";
 #include "../HandlerFactory.h"
 
-
 int acRemoteForceInterface::Init () {
         Action::Init();
-        bool need_file = true;
-        MPMDIntercomm inter;
+        pugi::xml_attribute attr = node.attribute("integrator");
+        if (attr) return ConnectRemoteForceInterface(attr.value());
+        ERROR("You must specify RemoteForceInterface integrator name\n");
+        return -1;
+}
+
+
+int acRemoteForceInterface::ConnectRemoteForceInterface(std::string integrator_) {
         pugi::xml_attribute attr;
-        char fn[STRING_LEN];
-        std::string filename;
         double units[3];
-        int N;
         units[0] = solver->units.alt("1m");
         units[1] = solver->units.alt("1s");
         units[2] = solver->units.alt("1kg");
-
+        
         solver->lattice->RFI.setUnits(units[0],units[1],units[2]);
         solver->lattice->RFI.CanCopeWithUnits(false);
 
-        printf("uni:%d - world:%d\n",MPMD.universe_size, MPMD.world_size);
-        N = MPMD.universe_size - MPMD.world_size;
-
-        inter = MPMD["ESYSPARTICLE"];
-        if (inter) need_file = false;
-
-        if (need_file) {
-                attr = node.attribute("script");
-                if (attr) {
-                        sprintf(fn,"%s",attr.value());
-                        filename = attr.value();
-                        need_file = false;
-                }
-        }
-        if (need_file) {
-                xcirc = false;
-                ycirc = false; //JM
-                zcirc = false; //JM
-                particle_type = "NRotSphere";
-                sim = "sim";
-                gridSpacing = 25.0;
-                verletDist = 5.0;
-                double sx,sy,sz; // Size of the domain for ESYS
-                attr = node.attribute("particle");
-                if (attr) particle_type = attr.value();
-                if (particle_type == "NRotSphere") {
-                } else if (particle_type == "RotSphere") {
-                } else {
-                        ERROR("Unknown particle type in ESYS\n");
-                        return -1;
-                }
-                attr = node.attribute("gridSpacing");
-                if (attr) gridSpacing = attr.as_double();
-                attr = node.attribute("verletDist");
-                if (attr) verletDist = attr.as_double();
-                attr = node.attribute("esys-object");
-                if (attr) sim = attr.value();
-                
-                /*
-                attr = node.attribute("periodic");
-                if (attr) {
-                        if (strcmp(attr.value(),"x") == 0) {
-                                xcirc = true;
-                        } else if (strcmp(attr.value(),"") == 0) {
-                                xcirc = false;
-                        } else {
-                                ERROR("ESYS-Particles can be only periodic in X direction\n");
-                                return -1;
-                        }
-                } */
-                //JM Version for full periodicity
-                attr = node.attribute("periodic");
-                if (attr) {
-                        if (strcmp(attr.value(),"x") == 0) {
-                                xcirc = true;
-                        } else if (strcmp(attr.value(),"y") == 0) {
-                                ycirc = true;
-                        } else if (strcmp(attr.value(),"z") == 0) {
-                                zcirc = true;
-                        } else if (strcmp(attr.value(),"x+y") == 0) {
-                                xcirc = true;
-                                ycirc = true;
-                        } else if (strcmp(attr.value(),"x+z") == 0) {
-                                xcirc = true;
-                                zcirc = true;
-                        } else if (strcmp(attr.value(),"y+z") == 0) {
-                                ycirc = true;
-                                zcirc = true;
-                        } else if (strcmp(attr.value(),"x+y+z") == 0) {
-                                xcirc = true;
-                                ycirc = true;
-                                zcirc = true;
-                        } else if (strcmp(attr.value(),"") == 0) {
-                                xcirc = false;
-                                ycirc = false;
-                                zcirc = false;
-                        } else {
-                                ERROR("Incorrect input options use e.g. x+y\n");
-                                return -1;
-                        }
-                }
-                        
-                sx = solver->mpi.totalregion.nx;
-                sy = solver->mpi.totalregion.ny;
-                sz = solver->mpi.totalregion.nz;
-                
-                int workers = N - 1;
-                if (workers < 1) {
-                        ERROR("ESYS-P: No place for workers (you need at least 2 additionals processes)\n");
-                        return -1;
-                }
-                int nx=1, ny=1, nz=1;
-                {
-                        int nx0, ny0, nz0;
-                        int tot, tot1;
-                        
-                        //JM 
-                        int xper, yper, zper;
-                        xper = xcirc ? 1 : 0;
-                        yper = ycirc ? 1 : 0;
-                        zper = zcirc ? 1 : 0;                        
-                        
-                        tot=0;
-                        nx0 = solver->mpi.divx;
-                        ny0 = solver->mpi.divy;
-                        nz0 = solver->mpi.divz;
-                        if (nx0 <= xper) nx0 = xper + 1;
-                        if (ny0 <= yper) ny0 = yper + 1;
-                        if (nz0 <= zper) nz0 = zper + 1;
-                        output("%dx%dx%d\n",nx0, ny0, nz0);
-                        //JM *per additions to account for periodicity in multiple directions (hopefully ...)
-                        for (int nx1=1; nx1<=nx0; nx1++) if (nx0 % nx1 == 0) {
-                                for (int ny1=1; ny1<=ny0; ny1++) if (ny0 % ny1 == 0) {
-                                        for (int nz1=1; nz1<=nz0; nz1++) if (nz0 % nz1 == 0) {
-                                                int tot1 = nx1*ny1*nz1;
-                                                if (tot1 <= workers) {
-                                                        if (workers % tot1 == 0) {
-                                                                int nx_ = workers / (ny1 * nz1);
-                                                                if ((nx_ > xper) && (ny1 > yper) && (nz1 > zper)) {
-                                                                        if (tot1 > tot) {
-                                                                                tot = tot1;
-                                                                                nx = workers / (ny1 * nz1);
-                                                                                ny = ny1;
-                                                                                nz = nz1;
-                                                                        }
-                                                                }
-                                                        }
-                                                }
-                                        }
-                                }
-                        }
-                        if (tot == 0) {
-                                output("Error may be due to periodicity in multiple directions calculation");
-                                ERROR("ESYS-P: Cannot find a good division. Requested workers (%d) do not fit well with TCLB division (%dx%dx%d)\n", workers, nx0, ny0, nz0);
-                                return -1;
-                        }
-                }
-                output("ESYS-P: Will be running at %dx%dx%d\n", nx, ny, nz);
-
-                if (xcirc) {
-                        if (nx < 2) {
-                                ERROR("ESYS-P can be periodic in X only when there are 2 processes in this direction.\n");
-                                return -1;
-                        }
-                }
-                //JM
-                if (ycirc) {
-                        if (ny < 2) {
-                                ERROR("ESYS-P can be periodic in Y only when there are 2 processes in this direction.\n");
-                                return -1;
-                        }
-                }
-                if (zcirc) {
-                        if (nz < 2) {
-                                ERROR("ESYS-P can be periodic in Z only when there are 2 processes in this direction.\n");
-                                return -1;
-                        }
-                }
-
-                double maxRad = 10;
-
-        //	solver->outGlobalFile("ESYS", ".py", fn);
-                sprintf(fn, "%s_%s.py", solver->info.outpath, "ESYS");
-                output("ESYS-P: config: %s\n", fn);
-                if (D_MPI_RANK == 0) {
-                        FILE * f = fopen(fn, "wt");
-                        fprintf(f, "from esys.lsm import *\n");
-                        fprintf(f, "from esys.lsm.util import Vec3, BoundingBox\n");
-                        fprintf(f, "from esys.lsm.geometry import *\n\n");
-                        fprintf(f, "%s = LsmMpi(numWorkerProcesses=%d, mpiDimList=[%d,%d,%d])\n", sim.c_str(), nx*ny*nz, nx, ny, nz);
-                        fprintf(f, "%s.initNeighbourSearch( particleType=\"%s\", gridSpacing=%lg, verletDist=%lg )\n", sim.c_str(), particle_type.c_str(), gridSpacing, verletDist);
-                        fprintf(f, "%s.setSpatialDomain( BoundingBox(Vec3(%lg,%lg,%lg), Vec3(%lg,%lg,%lg)), circDimList = [%s, %s, %s])\n", //JM [%s,False, False]
-                                sim.c_str(),
-                                0.0, 0.0, 0.0,
-                                sx/units[0], sy/units[0], sz/units[0],
-                                xcirc ? "True" : "False",
-                                ycirc ? "True" : "False",
-                                zcirc ? "True" : "False");
-                        fprintf(f, "%s.setTimeStepSize(%lg)\n", sim.c_str(), 1.0/units[1]);
-                        fprintf(f, "%s.setNumTimeSteps(%d)\n", sim.c_str(), Next(solver->iter));
-                        fprintf(f, "%s.createInteractionGroup(	RemoteForcePrms(name=\"tclb\", remote_name=\"%s\", max_rad=%lg) )\n", sim.c_str(), MPMD.name.c_str(), maxRad);
-                        fprintf(f, "output_prefix=\"%s_%s\"\n", solver->info.outpath, "ESYS");
-                        fprintf(f, "def output_path(x):\n\treturn output_prefix + x\n");
-                        fprintf(f, "%s\n", node.child_value());
-                        fprintf(f, "%s.run()\n", sim.c_str());
-                        fflush(f);
-                        fclose(f);
-                }
-
-        }
-        MPI_Barrier(MPMD.local);
-
-        char * args[] = {fn,NULL};
-        
-//        solver->lattice->RFI.Start("esysparticle",args, units);
+        inter = MPMD[integrator_];
         if (! inter) {
-                output("Spawning esysparticle with script: %s\n", fn);
-                inter = MPMD.Spawn("esysparticle", args, N, MPI_INFO_NULL);
+                ERROR("Integrator %s not found in MPMD (that usualy means that you didn't run it)\n");
+                return -1;
         }
+        integrator = integrator_;
+        
+        MPI_Barrier(MPMD.local);
         solver->lattice->RFI.Connect(MPMD.work,inter.work);
+        
 	return 0;
 }
 

--- a/src/Handlers/acRemoteForceInterface.h
+++ b/src/Handlers/acRemoteForceInterface.h
@@ -1,5 +1,5 @@
-#ifndef ACSYNTHETICTURBULENCE_H
-#define ACSYNTHETICTURBULENCE_H
+#ifndef ACREMOTEFORCEINTERFACE_H
+#define ACREMOTEFORCEINTERFACE_H
 
 #include "../CommonHandler.h"
 
@@ -7,16 +7,12 @@
 #include "Action.h"
 
 class  acRemoteForceInterface  : public  Action  {
+        MPMDIntercomm inter;
+        std::string integrator;
 	public:
 	static std::string xmlname;
-	std::string particle_type;
-	std::string sim;
-	double gridSpacing;
-	double verletDist;
-	bool xcirc;
-	bool ycirc; //JM
-	bool zcirc; //JM
 	int Init ();
+	int ConnectRemoteForceInterface(std::string);
 };
 
-#endif // ACSYNTHETICTURBULENCE_H
+#endif // ACREMOTEFORCEINTERFACE_H

--- a/src/MPMD.hpp
+++ b/src/MPMD.hpp
@@ -129,8 +129,10 @@ public:
    inline ~MPMDHelper() {
    };
 
-   MPMDIntercomm& operator[](const std::string& key) {
-      return intercomm[key];
+   MPMDIntercomm operator[](const std::string& key) {
+      intercomm_map::iterator it = intercomm.find(key);
+      if (it != intercomm.end()) return it->second;
+      return MPMDIntercomm();
    };
 
    
@@ -278,7 +280,7 @@ public:
          ret.work_size = 0;
       }
       ret.connected = true;
-      intercomm.insert(make_pair(ret.name, ret));
+      intercomm[ret.name] = ret;
       return ret;
    }
 


### PR DESCRIPTION
This resolves #223 
After this change one needs to use `<ESYSParticle>` element in stead of the old `<RemoteForceInterface>` element. Now the `<RemoteForceInterface>` is the element **only activating** the RFI mechanics, and can be used with other codes.