### PR TITLE
HDF5 / Xdmf support

### DIFF
--- a/doc/elements.yaml
+++ b/doc/elements.yaml
@@ -97,6 +97,34 @@ HDF5:
       val:
         string: outname
       comment: Name of the HDF5 and Xdmf file.
+    - name: compress
+      val: 
+        select:
+          - true
+          - false
+      comment: Use ZLIB deflation filter to compress output
+    - name: write_xdmf
+      val: 
+        select:
+          - true
+          - false
+      comment: Write Xdmf accompaning file describing the data for visualisation
+    - name: point_data
+      val:
+        select:
+          - true
+          - false
+      comment: Write Xdmf that described the data as Point Data and not Cell Data
+    - name: chunk
+      val:
+        string: 3int
+      comment: HDF5 Chunk size (not supported yet)
+    - name: precision
+      val:
+        select:
+          - float
+          - double
+      comment: "Select the precision of the HDF5 data. If this doesn't match the calculation type, this can conflict with compression."
 
 TXT:
   comment: Export data to TXT file

--- a/doc/elements.yaml
+++ b/doc/elements.yaml
@@ -81,6 +81,23 @@ VTK:
         string: outname
       comment: Name of the VTK file. 
 
+HDF5:
+  comment: Export HDF5 data file and Xdmf description
+  example: <HDF5 Iterations="1000" what="U,Rho"/>
+  type: callback
+  attr:
+    - name: what
+      optional: true
+      val:
+        list:
+        - special: Quantities
+        - special: GeometryComponents
+      comment: List of Quantities and Geometry Components to export.
+    - name: name
+      val:
+        string: outname
+      comment: Name of the HDF5 and Xdmf file.
+
 TXT:
   comment: Export data to TXT file
   type: callback

--- a/src/Handlers/cbHDF5.cpp
+++ b/src/Handlers/cbHDF5.cpp
@@ -26,7 +26,7 @@ int cbHDF5::Init () {
 int cbHDF5::DoIt () {
 #ifdef WITH_HDF5
 		Callback::DoIt();
-		return hdf5WriteLattice(nm.c_str(), solver->lattice, solver->units, &s);
+		return hdf5WriteLattice(nm.c_str(), solver, &s);
 #else
 		return -1;
 #endif

--- a/src/Handlers/cbHDF5.cpp
+++ b/src/Handlers/cbHDF5.cpp
@@ -1,0 +1,28 @@
+#include "cbHDF5.h"
+std::string cbHDF5::xmlname = "HDF5";
+#include "../HandlerFactory.h"
+#include "../hdf5Lattice.h"
+
+int cbHDF5::Init () {
+		Callback::Init();
+		pugi::xml_attribute attr = node.attribute("name");
+		nm = "HDF5";
+		if (attr) nm = attr.value();
+		attr = node.attribute("what");
+		if (attr) {
+		        s.add_from_string(attr.value(),',');
+                } else {
+                        s.add_from_string("all",',');
+                }
+		return 0;
+	}
+
+
+int cbHDF5::DoIt () {
+		Callback::DoIt();
+		return hdf5WriteLattice(nm.c_str(), solver->lattice, solver->units, &s);
+};
+
+
+// Register the handler (basing on xmlname) in the Handler Factory
+template class HandlerFactory::Register< GenericAsk< cbHDF5 > >;

--- a/src/Handlers/cbHDF5.cpp
+++ b/src/Handlers/cbHDF5.cpp
@@ -4,6 +4,7 @@ std::string cbHDF5::xmlname = "HDF5";
 #include "../hdf5Lattice.h"
 
 int cbHDF5::Init () {
+	options = 0;
 	Callback::Init();
 #ifdef WITH_HDF5
 		pugi::xml_attribute attr = node.attribute("name");
@@ -16,7 +17,7 @@ int cbHDF5::Init () {
                         s.add_from_string("all",',');
                 }
 
-                deflate = true;
+                bool deflate = true;
 		attr = node.attribute("compress");
 		if (attr) {
 			if (strcmp(attr.value(),"true") == 0) {
@@ -27,7 +28,8 @@ int cbHDF5::Init () {
 				ERROR("compress attribute should be true or false (not '%s')\n", attr.value());
 			}
 		}
-		write_xdmf = true;
+		if (deflate) options = options | HDF5_DEFLATE;
+		bool write_xdmf = true;
 		attr = node.attribute("write_xdmf");
 		if (attr) {
 			if (strcmp(attr.value(),"true") == 0) {
@@ -38,7 +40,7 @@ int cbHDF5::Init () {
 				ERROR("write_xdmf attribute should be true or false (not '%s')\n", attr.value());
 			}
 		}
-                
+                if (write_xdmf) options = options | HDF5_WRITE_XDMF;
 		attr = node.attribute("chunk");
 		if (attr) {
 			ERROR("Supplying chunk size is not yet supported");
@@ -78,7 +80,7 @@ int cbHDF5::Init () {
 int cbHDF5::DoIt () {
 #ifdef WITH_HDF5
 		Callback::DoIt();
-		return hdf5WriteLattice(nm.c_str(), solver, &s, chunkdim, write_xdmf, deflate);
+		return hdf5WriteLattice(nm.c_str(), solver, &s, chunkdim, options);
 #else
 		return -1;
 #endif

--- a/src/Handlers/cbHDF5.cpp
+++ b/src/Handlers/cbHDF5.cpp
@@ -41,6 +41,18 @@ int cbHDF5::Init () {
 			}
 		}
                 if (write_xdmf) options = options | HDF5_WRITE_XDMF;
+		bool point_data = false;
+		attr = node.attribute("point_data");
+		if (attr) {
+			if (strcmp(attr.value(),"true") == 0) {
+				point_data = true;
+			} else if (strcmp(attr.value(),"false") == 0) {
+				point_data = false;
+			} else {
+				ERROR("point_data attribute should be true or false (not '%s')\n", attr.value());
+			}
+		}
+                if (point_data) options = options | HDF5_WRITE_POINT;
 		attr = node.attribute("chunk");
 		bool calc_double;
 #ifdef CALC_DOUBLE_PRECISION

--- a/src/Handlers/cbHDF5.cpp
+++ b/src/Handlers/cbHDF5.cpp
@@ -26,7 +26,7 @@ int cbHDF5::Init () {
 int cbHDF5::DoIt () {
 #ifdef WITH_HDF5
 		Callback::DoIt();
-		return hdf5WriteLattice(nm.c_str(), solver, &s);
+		return hdf5WriteLattice(nm.c_str(), solver, &s, true);
 #else
 		return -1;
 #endif

--- a/src/Handlers/cbHDF5.cpp
+++ b/src/Handlers/cbHDF5.cpp
@@ -42,6 +42,33 @@ int cbHDF5::Init () {
 		}
                 if (write_xdmf) options = options | HDF5_WRITE_XDMF;
 		attr = node.attribute("chunk");
+		bool calc_double;
+#ifdef CALC_DOUBLE_PRECISION
+                        calc_double = true;
+#else
+                        calc_double = false;
+#endif
+		bool write_double;
+		write_double = calc_double;
+		attr = node.attribute("precision");
+		if (attr) {
+			if (strcmp(attr.value(),"double") == 0) {
+				write_double = true;
+			} else if (strcmp(attr.value(),"float") == 0) {
+	                        write_double = false;
+			} else {
+				ERROR("write_double attribute should be double of false\n", attr.value());
+			}
+		}
+		if (write_double != calc_double) {
+			if (deflate) {
+				NOTICE("Writing a different type then type you calculate, probably cannot be combined with deflate");
+			} else {
+				notice("Writing a different type then type you calculate");
+			}
+		}		
+                if (write_double) options = options | HDF5_WRITE_DOUBLE;
+		attr = node.attribute("chunk");
 		if (attr) {
 			ERROR("Supplying chunk size is not yet supported");
 			return -1;

--- a/src/Handlers/cbHDF5.cpp
+++ b/src/Handlers/cbHDF5.cpp
@@ -4,7 +4,8 @@ std::string cbHDF5::xmlname = "HDF5";
 #include "../hdf5Lattice.h"
 
 int cbHDF5::Init () {
-		Callback::Init();
+	Callback::Init();
+#ifdef WITH_HDF5
 		pugi::xml_attribute attr = node.attribute("name");
 		nm = "HDF5";
 		if (attr) nm = attr.value();
@@ -14,13 +15,21 @@ int cbHDF5::Init () {
                 } else {
                         s.add_from_string("all",',');
                 }
-		return 0;
+                return 0;
+#else
+		ERROR("No hdf5 support at configure\n");
+		return -1;
+#endif
 	}
 
 
 int cbHDF5::DoIt () {
+#ifdef WITH_HDF5
 		Callback::DoIt();
 		return hdf5WriteLattice(nm.c_str(), solver->lattice, solver->units, &s);
+#else
+		return -1;
+#endif
 };
 
 

--- a/src/Handlers/cbHDF5.h
+++ b/src/Handlers/cbHDF5.h
@@ -1,0 +1,18 @@
+#ifndef CBHDF5_H
+#define CBHDF5_H
+
+#include "../CommonHandler.h"
+
+#include "vHandler.h"
+#include "Callback.h"
+
+class  cbHDF5  : public  Callback  {
+	std::string nm;
+	name_set s;
+	public:
+	static std::string xmlname;
+int Init ();
+int DoIt ();
+};
+
+#endif // CBHDF5_H

--- a/src/Handlers/cbHDF5.h
+++ b/src/Handlers/cbHDF5.h
@@ -9,10 +9,13 @@
 class  cbHDF5  : public  Callback  {
 	std::string nm;
 	name_set s;
-	public:
+	unsigned long int chunkdim[3];
+	bool write_xdmf;
+	bool deflate;
+public:
 	static std::string xmlname;
-int Init ();
-int DoIt ();
+	int Init ();
+	int DoIt ();
 };
 
 #endif // CBHDF5_H

--- a/src/Handlers/cbHDF5.h
+++ b/src/Handlers/cbHDF5.h
@@ -10,8 +10,7 @@ class  cbHDF5  : public  Callback  {
 	std::string nm;
 	name_set s;
 	unsigned long int chunkdim[3];
-	bool write_xdmf;
-	bool deflate;
+	unsigned int options;
 public:
 	static std::string xmlname;
 	int Init ();

--- a/src/Solver.h.Rt
+++ b/src/Solver.h.Rt
@@ -2,6 +2,9 @@
         source("conf.R")
 	c_header();
 ?>
+#ifndef SOLVER_H
+#define SOLVER_H
+
 #include "Consts.h"
 #include "pugixml.hpp"
 #include "Global.h"
@@ -112,6 +115,19 @@ class Solver {
                 sprintf(out, "%s_%s_P%02d%s", info.outpath, name, mpi_rank, suffix);
 		mkpath(out);
         };
+/// Generate a Iteration-specific collective filename
+/**
+ Generate a filename starting with the output prefix, continuing with the name,
+ iteration number and suffix (without process number)
+ \param name Appendix added to the filename
+ \param suffix Suffix (.vti, .csv, etc) of the file
+ \param out Buffer for the returned file name
+*/
+        inline void outIterCollectiveFile(const char * name, const char * suffix, char * out) {
+                sprintf(out, "%s_%s_%08d%s", info.outpath, name, iter, suffix);
+		mkpath(out);
+        };
+
 /// Set output prefix
 	void setOutput(const char * out);
 	void setUnit(std::string, std::string, std::string);
@@ -212,3 +228,5 @@ inline int GlobalInObj(int i) { <?R
    return i + <?%s Settings$Index[i] ?>; <?R
    } ?>
 }
+
+#endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -20,8 +20,11 @@
 /* Using NLOpt */
 #undef WITH_NLOPT
 
-/* Using NLOpt */
+/* Using R */
 #undef WITH_R
+
+/* Using HDF5 */
+#undef WITH_HDF5
 
 /* CUDA ARCH */
 #undef CUDA_ARCH

--- a/src/config.mk.in
+++ b/src/config.mk.in
@@ -16,7 +16,7 @@ SOURCE_CU=Global.cu Lattice.cu main.cu vtkLattice.cu vtkOutput.cu cross.cu cuda.
 SOURCE=$(SOURCE_CU)
 HEADERS=Global.h gpu_anim.h LatticeContainer.h Lattice.h Region.h vtkLattice.h vtkOutput.h cross.h gl_helper.h Dynamics.h Dynamics.hp types.h pugixml.hpp pugiconfig.hpp
 
-OBJ  = vtkOutput.o cuda.o Global.o Lattice.o vtkLattice.o cross.o pugixml.o Geometry.o def.o unit.o Solver.o SyntheticTurbulence.o Sampler.o ZoneSettings.o RemoteForceInterface.o
+OBJ  = vtkOutput.o cuda.o Global.o Lattice.o vtkLattice.o cross.o pugixml.o Geometry.o def.o unit.o Solver.o SyntheticTurbulence.o Sampler.o ZoneSettings.o RemoteForceInterface.o hdf5Lattice.o
 
 AOUT=main
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -308,19 +308,33 @@ AC_CHECK_LIB([mpi], [MPI_Recv],[],[
 
 
 AC_MSG_CHECKING([HDF5 path])
+need_hdf5="no"
+has_hdf5="no"
 if test "x${with_hdf5}" != "xno"; then
 	if test "x${with_hdf5}" != "x"; then
-		if test -d "${with_hdf5}"; then
-			LDFLAGS="${LDFLAGS} -L${with_hdf5}/lib"
-			CPPFLAGS="${CPPFLAGS} -I${with_hdf5}/include"
-			AC_MSG_RESULT([${with_hdf5}])
+		if test "x${with_hdf5}" == "xyes"; then
+			need_hdf5=yes
 		else
-			AC_MSG_ERROR([${with_hdf5}: path not found])
+			if test -d "${with_hdf5}"; then
+				LDFLAGS="${LDFLAGS} -L${with_hdf5}/lib"
+				CPPFLAGS="${CPPFLAGS} -I${with_hdf5}/include"
+				need_hdf5=yes
+				AC_MSG_RESULT([${with_hdf5}])
+			else
+				AC_MSG_ERROR([${with_hdf5}: path not found])
+			fi
 		fi
 	fi
-	AC_CHECK_HEADERS([hdf5.h],[],[AC_MSG_ERROR([Didn't find hdf5.h])])
-	AC_CHECK_LIB([hdf5], [H5Pset_fapl_mpio],[],[AC_MSG_ERROR([Didn't find hdf5])])
-	AC_DEFINE([WITH_HDF5], [1], [Using HDF5])
+	has_hdf5="yes"
+	AC_CHECK_HEADERS([hdf5.h],[],[has_hdf5="no"])
+	AC_CHECK_LIB([hdf5], [H5Pset_fapl_mpio],[],[has_hdf5="no"])
+	if test "x${has_hdf5}" == "xyes"; then
+		AC_DEFINE([WITH_HDF5], [1], [Using HDF5])
+	else
+		if test "x${need_hdf5}" == "xyes"; then
+			AC_MSG_ERROR([HDF5 not found])
+		fi
+	fi
 fi
 
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -27,6 +27,10 @@ AC_ARG_WITH([mpi-lib],
 		[specify the full path to your mpi shared libraries, e.g. /usr/lib/openmpi/]),
 	[MPI_LIB="$withval"])
 
+AC_ARG_WITH([hdf5],
+	AC_HELP_STRING([--with-hdf5=hdf5],
+		[specify the full path to your hdf5 installation]))
+
 AC_ARG_ENABLE([graphics],
 	AC_HELP_STRING([--enable-graphics],
 		[make a GUI version]))
@@ -283,10 +287,6 @@ else
 fi
 CPPFLAGS="${CPPFLAGS} -I${MPI_INCLUDE}"
 
-
-
-
-
 AC_MSG_CHECKING([MPI library path])
 if test -z "${MPI_LIB}"; then
 	if test -z "${MPI}"; then
@@ -305,6 +305,23 @@ AC_CHECK_LIB([mpi], [MPI_Recv],[],[
 		AC_MSG_ERROR([Didn't find MPI Library])
 	])
 ])
+
+
+AC_MSG_CHECKING([HDF5 path])
+if test "x${with_hdf5}" != "xno"; then
+	if test "x${with_hdf5}" != "x"; then
+		if test -d "${with_hdf5}"; then
+			LDFLAGS="${LDFLAGS} -L${with_hdf5}/lib"
+			CPPFLAGS="${CPPFLAGS} -I${with_hdf5}/include"
+			AC_MSG_RESULT([${with_hdf5}])
+		else
+			AC_MSG_ERROR([${with_hdf5}: path not found])
+		fi
+	fi
+	AC_CHECK_HEADERS([hdf5.h],[],[AC_MSG_ERROR([Didn't find hdf5.h])])
+	AC_CHECK_LIB([hdf5], [H5Pset_fapl_mpio],[],[AC_MSG_ERROR([Didn't find hdf5])])
+	AC_DEFINE([WITH_HDF5], [1], [Using HDF5])
+fi
 
 
 if  test "x${with_python}" == "xyes"; then

--- a/src/glue.hpp
+++ b/src/glue.hpp
@@ -1,0 +1,48 @@
+#ifndef GLUE_H
+#define GLUE_H
+
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <iomanip>
+
+class Glue {
+private:
+    std::stringstream s;
+    std::string sep;
+    std::string val;
+    bool empty;
+public:
+    inline Glue() {
+        s << std::setprecision(14);
+        s << std::scientific;
+        empty = true;
+    }
+    inline Glue& operator () (std::string sep_ = "") {
+        s.str(std::string());
+        sep = sep_;
+        empty = true;
+        return *this;
+    }
+    template <class T> inline Glue& operator<< (const std::pair<T*, int>& t) {
+        for (int i=0; i<t.second; i++) (*this) << t.first[i];
+        return *this;
+    }
+    template <class T> inline Glue& operator<< (const T& t) {
+        if (sep == "" || empty)
+            s << t;
+        else
+            s << sep << t;
+        empty = false;
+        return *this;
+    }
+    inline const char* c_str () {
+        val = s.str();
+        return val.c_str();
+    }
+    inline operator const char* () {
+        return this->c_str();
+    }
+};
+
+#endif

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -155,10 +155,19 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 			char * fieldname = "<?%s q$name ?>";
 			bool vector = <?%s ifelse(q$vector, "true", "false") ?>;
 #ifndef CALC_DOUBLE_PRECISION
-			hid_t type = H5T_NATIVE_FLOAT;
+			hid_t input_type = H5T_NATIVE_FLOAT;
 #else
-			hid_t type = H5T_NATIVE_DOUBLE;
+			hid_t input_type = H5T_NATIVE_DOUBLE;
 #endif
+			hid_t output_type;
+			int output_precision;
+			if (options & HDF5_WRITE_DOUBLE) {
+				output_type = H5T_NATIVE_DOUBLE;
+				output_precision = 8;
+			} else {
+				output_type = H5T_NATIVE_FLOAT;
+				output_precision = 4;
+			}
 			int rank = 3;
 			if (vector) rank = 4;
 			filespace = H5Screate_simple(rank, totaldim, NULL); 
@@ -169,7 +178,7 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 			if (status < 0) return H5Eprint1(stderr);
 			if (options & HDF5_DEFLATE) status = H5Pset_deflate (plist_id, 6);
 			if (status < 0) return H5Eprint1(stderr);
-	                    	dset_id = H5Dcreate2(file_id, fieldname, H5T_NATIVE_DOUBLE, filespace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
+	                    	dset_id = H5Dcreate2(file_id, fieldname, output_type, filespace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
 			H5Pclose(plist_id);
 
                     	status = H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset, ones, ones, dim);
@@ -182,7 +191,7 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 			debug0("filespace: %lld memsize: %lld\n", H5Sget_select_npoints(filespace), H5Sget_select_npoints(memspace));
 			plist_id = H5Pcreate(H5P_DATASET_XFER);
 				H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
-				status = H5Dwrite(dset_id, H5T_NATIVE_DOUBLE, memspace, filespace, plist_id, tmp);
+				status = H5Dwrite(dset_id, input_type, memspace, filespace, plist_id, tmp);
 			
 			H5Pclose(plist_id);
 			H5Sclose(filespace);
@@ -198,19 +207,21 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 			xdmf_dataitem.append_attribute("DataType") = "Float";
 			xdmf_dataitem.append_attribute("Dimensions") = glue(" ") << std::make_pair(totaldim, rank);
 			xdmf_dataitem.append_attribute("Format") = "HDF";
-			xdmf_dataitem.append_attribute("Precision") = 8;
+			xdmf_dataitem.append_attribute("Precision") = output_precision;
 			xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(":") << basename << fieldname);
 			std::string xdmf_dataitem_path = NameXPath(xdmf_dataitem);
-			xdmf_attribute = xdmf_grid.append_child("Attribute");
-			xdmf_attribute.append_attribute("Center") = "Cell";
-			if (vector) xdmf_attribute.append_attribute("AttributeType") = "Vector";
-			xdmf_attribute.append_attribute("Name") = glue("_") << fieldname << "LB";
-			xdmf_dataitem = xdmf_attribute.append_child("DataItem");
-			xdmf_dataitem.append_attribute("ItemType") = "Function";
-			xdmf_dataitem.append_attribute("Function") = glue(" ") << unit << "*" << "$0";
-			xdmf_dataitem.append_attribute("Dimensions") = glue(" ") << std::make_pair(totaldim, rank);
-			xdmf_dataitem = xdmf_dataitem.append_child("DataItem");
-			xdmf_dataitem.append_attribute("Reference") = xdmf_dataitem_path.c_str();
+			if (options & HDF5_WRITE_LBM) {
+				xdmf_attribute = xdmf_grid.append_child("Attribute");
+				xdmf_attribute.append_attribute("Center") = "Cell";
+				if (vector) xdmf_attribute.append_attribute("AttributeType") = "Vector";
+				xdmf_attribute.append_attribute("Name") = glue("_") << fieldname << "LB";
+				xdmf_dataitem = xdmf_attribute.append_child("DataItem");
+				xdmf_dataitem.append_attribute("ItemType") = "Function";
+				xdmf_dataitem.append_attribute("Function") = glue(" ") << unit << "*" << "$0";
+				xdmf_dataitem.append_attribute("Dimensions") = glue(" ") << std::make_pair(totaldim, rank);
+				xdmf_dataitem = xdmf_dataitem.append_child("DataItem");
+				xdmf_dataitem.append_attribute("Reference") = xdmf_dataitem_path.c_str();
+			}
 		}
 	}
 	<?R }; ifdef(); ?>

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -6,16 +6,24 @@
 #include <assert.h>
 #include <mpi.h>
 #include "cross.h"
-#include "vtkLattice.h"
+#include "hdf5Lattice.h"
 #include "Global.h"
 
 #ifdef WITH_HDF5
+	#include <hdf5.h>
+#endif
 
-#include <hdf5.h>
 
-
-int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv units, name_set * what)
+int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what)
 {
+#ifdef WITH_HDF5
+	Lattice * lattice = solver->lattice;
+	UnitEnv * units = &solver->units;
+
+	solver->print("writing hdf5");
+	char filename[2*STRING_LEN];
+	solver->outIterCollectiveFile(nm, ".h5", filename);
+
 	size_t size;
 	lbRegion reg = lattice->region;
 	lbRegion totalreg = lattice->mpi.totalregion;
@@ -29,21 +37,12 @@ int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv units, na
     hsize_t	ones[4];	         
     int         i;
     herr_t	status;
+    hid_t plist_id;
 
 	ones[0] = 1;
 	ones[1] = 1;
 	ones[2] = 1;
 	ones[3] = 1;
-
-    MPI_Comm comm  = MPMD.local;
-    MPI_Info info  = MPI_INFO_NULL;
-
-	hid_t plist_id;
-
-	plist_id = H5Pcreate(H5P_FILE_ACCESS);
-		H5Pset_fapl_mpio(plist_id, comm, info);
-	    	file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
-    	H5Pclose(plist_id);
 
     totaldim[0] = totalreg.nz;
     totaldim[1] = totalreg.ny;
@@ -58,10 +57,19 @@ int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv units, na
     offset[2] = reg.dx;
     offset[3] = 0;
 
-	printf("[%d] dim: %lldx%lldx%lld (%lldx%lldx%lld+%lld,%lld,%lld)\n", lattice->mpi.rank,
+	debug1("[%2d] %s dim: %lldx%lldx%lld (%lldx%lldx%lld+%lld,%lld,%lld)\n", lattice->mpi.rank,
+		filename,
 		totaldim[0], totaldim[1], totaldim[2],
 		dim[0], dim[1], dim[2],
 		offset[0], offset[1], offset[2]);
+
+    MPI_Comm comm  = MPMD.local;
+    MPI_Info info  = MPI_INFO_NULL;
+
+	plist_id = H5Pcreate(H5P_FILE_ACCESS);
+		H5Pset_fapl_mpio(plist_id, comm, info);
+	    	file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
+    	H5Pclose(plist_id);
 
 	<?R for (q in rows(Quantities)) { ifdef(q$adjoint); ?>
 	{
@@ -84,11 +92,11 @@ int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv units, na
                     	status = H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset, ones, ones, dim);
                     	if (status < 0) return H5Eprint1(stderr);
 
-			double v = units.alt("<?%s q$unit ?>");
+			double v = units->alt("<?%s q$unit ?>");
 	                <?%s q$type ?>* tmp = new <?%s q$type ?>[size];
                         lattice->Get<?%s q$name ?>(reg, tmp, 1/v);
 
-			printf("filespace: %lld memsize: %lld\n", H5Sget_select_npoints(filespace), H5Sget_select_npoints(memspace));
+			debug0("filespace: %lld memsize: %lld\n", H5Sget_select_npoints(filespace), H5Sget_select_npoints(memspace));
 			plist_id = H5Pcreate(H5P_DATASET_XFER);
 				H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
 				status = H5Dwrite(dset_id, H5T_NATIVE_DOUBLE, memspace, filespace, plist_id, tmp);
@@ -104,13 +112,8 @@ int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv units, na
 	<?R }; ifdef(); ?>
 
     H5Fclose(file_id);
-
 	return 0;
-}
 #else
-
-int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv units, name_set * what) {
 	return -1;
-}
-
 #endif
+}

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -27,7 +27,7 @@ std::string NameXPath(const pugi::xml_node& node) {
 	return path;
 }
 
-int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned long int * chunkdim_, bool write_xdmf, bool deflate)
+int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned long int * chunkdim_, unsigned int options)
 {
 #ifdef WITH_HDF5
 	Glue glue;
@@ -167,7 +167,7 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 			
 			status = H5Pset_chunk (plist_id, rank, chunkdim);
 			if (status < 0) return H5Eprint1(stderr);
-			if (deflate) status = H5Pset_deflate (plist_id, 6);
+			if (options & HDF5_DEFLATE) status = H5Pset_deflate (plist_id, 6);
 			if (status < 0) return H5Eprint1(stderr);
 	                    	dset_id = H5Dcreate2(file_id, fieldname, H5T_NATIVE_DOUBLE, filespace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
 			H5Pclose(plist_id);
@@ -218,7 +218,7 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 	H5Fclose(file_id);
 
 
-	if (write_xdmf) {
+	if (options & HDF5_WRITE_XDMF) {
 		if (lattice->mpi.rank == 0) {
 		    solver->outIterCollectiveFile(nm, ".xmf", filename);
 		    xdmf_doc.save_file(filename);

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -1,0 +1,116 @@
+<?R
+	source("conf.R")
+	c_header();
+?>
+#include <stdio.h>
+#include <assert.h>
+#include <mpi.h>
+#include "cross.h"
+#include "vtkLattice.h"
+#include "Global.h"
+
+#ifdef WITH_HDF5
+
+#include <hdf5.h>
+
+int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv units, name_set * what)
+{
+	size_t size;
+	lbRegion reg = lattice->region;
+	lbRegion totalreg = lattice->mpi.totalregion;
+	size = reg.size();
+
+    hid_t       file_id, dset_id;         /* file and dataset identifiers */
+    hid_t       filespace, memspace;      /* file and memory dataspace identifiers */
+    hsize_t     dimsf[3];                 /* dataset dimensions */
+    hsize_t     chunk_dims[3];            /* chunk dimensions */
+    int         *data;                    /* pointer to data buffer to write */
+    hsize_t	count[2];	          /* hyperslab selection parameters */
+    hsize_t	stride[2];
+    hsize_t	block[2];
+    hsize_t	offset[3];
+    int         i;
+    herr_t	status;
+
+
+    MPI_Comm comm  = MPMD.local;
+    MPI_Info info  = MPI_INFO_NULL;
+
+	hid_t plist_id;
+
+	plist_id = H5Pcreate(H5P_FILE_ACCESS);
+		H5Pset_fapl_mpio(plist_id, comm, info);
+	    	file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
+    	H5Pclose(plist_id);
+
+    dimsf[0] = totalreg.nz;
+    dimsf[1] = totalreg.ny;
+    dimsf[2] = totalreg.nx;
+    chunk_dims[0] = reg.nz;   
+    chunk_dims[1] = reg.ny;   
+    chunk_dims[2] = reg.nx;
+    offset[0] = reg.dz;
+    offset[1] = reg.dy;
+    offset[2] = reg.dx;
+
+	printf("[%d] dim: %lldx%lldx%lld (%lldx%lldx%lld+%lld,%lld,%lld)\n", lattice->mpi.rank,
+		dimsf[0], dimsf[1], dimsf[2],
+		chunk_dims[0], chunk_dims[1], chunk_dims[2],
+		offset[0], offset[1], offset[2]);
+
+    filespace = H5Screate_simple(3, dimsf, NULL); 
+    memspace  = H5Screate_simple(3, chunk_dims, NULL); 
+
+    count[0] = 1;
+    count[1] = 1;
+    count[2] = 1;
+    stride[0] = 1;
+    stride[1] = 1;
+    stride[2] = 1;
+    block[0] =  chunk_dims[0];
+    block[1] =  chunk_dims[1];
+    block[2] =  chunk_dims[2];
+
+	<?R for (q in rows(Quantities)[1]) { ifdef(q$adjoint); ?>
+	{
+		if (what->in("<?%s q$name ?>")) {
+			plist_id = H5Pcreate(H5P_DATASET_CREATE);
+	                    	dset_id = H5Dcreate(file_id, "<?%s q$name ?>", H5T_NATIVE_DOUBLE, filespace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
+			H5Pclose(plist_id);
+
+			hid_t filespace_ = H5Dget_space(dset_id);
+    
+                    	status = H5Sselect_hyperslab(filespace_, H5S_SELECT_SET, offset, stride, count, block);
+                    	if (status < 0) return H5Eprint1(stderr);
+
+			double v = units.alt("<?%s q$unit ?>");
+	                <?%s q$type ?>* tmp = new <?%s q$type ?>[size];
+                        lattice->Get<?%s q$name ?>(reg, tmp, 1/v);
+
+			printf("filespace: %lld memsize: %lld\n", H5Sget_select_npoints(filespace_), H5Sget_select_npoints(memspace));
+			plist_id = H5Pcreate(H5P_DATASET_XFER);
+				H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
+				status = H5Dwrite(dset_id, H5T_NATIVE_DOUBLE, memspace, filespace_, plist_id, tmp);
+			
+			H5Pclose(plist_id);
+			H5Sclose(filespace_);
+			H5Dclose(dset_id);
+
+			delete[] tmp;
+		}
+	}
+	<?R }; ifdef(); ?>
+
+    H5Sclose(filespace);
+    H5Sclose(memspace);
+    H5Fclose(file_id);
+
+	return 0;
+}
+#else
+
+int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv units, name_set * what) {
+	return -1;
+}
+
+#endif

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -216,8 +216,10 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool wri
 
 
 	if (write_xdmf) {
-	    solver->outIterCollectiveFile(nm, ".xmf", filename);
-	    xdmf_doc.save_file(filename);
+		if (lattice->mpi.rank == 0) {
+		    solver->outIterCollectiveFile(nm, ".xmf", filename);
+		    xdmf_doc.save_file(filename);
+		}
 	}
 
 	return 0;

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -14,41 +14,6 @@
 	#include <hdf5.h>
 #endif
 
-/*
-char xdmf_string[STRING_LEN*10];
-
-void xdmf_str_val(char* str, double val) { sprintf(str, "%lf", val); }
-void xdmf_str_val(char* str, float val) { sprintf(str, "%f", val); }
-void xdmf_str_val(char* str, int val) { sprintf(str, "%d", val); }
-void xdmf_str_val(char* str, long int val) { sprintf(str, "%ld", val); }
-void xdmf_str_val(char* str, long long int val) { sprintf(str, "%lld", val); }
-void xdmf_str_val(char* str, unsigned long long int val) { sprintf(str, "%llu", val); }
-void xdmf_str_val(char* str, char* val) { sprintf(str, "%s", val); }
-
-template <typename T>
-void xdmf_str_val(char* str, int len, T* tab, char sep) {
-	for (int i=0; i<len; i++) {
-		xdmf_str_val(str, tab[i]);
-		if (i == len - 1) break;
-		str += strlen(str);
-		str[0] = sep;
-		str++;
-	}
-}
-
-template <typename T>
-char* xdmf_val(int len, T* tab, char sep) {
-	xdmf_str_val<T>(xdmf_string, len, tab, sep);
-	return xdmf_string;
-}
-
-template <typename T>
-char* xdmf_val(int len, T* tab) {
-	return xdmf_val<T>(len, tab, ' ');
-}
-*/
-
-
 std::string NameXPath(const pugi::xml_node& node) {
 	std::string path;
 	if (node.parent()) {

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -14,7 +14,40 @@
 #endif
 
 
-int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what)
+char xdmf_string[STRING_LEN*10];
+
+void xdmf_str_val(char* str, double val) { sprintf(str, "%lf", val); }
+void xdmf_str_val(char* str, float val) { sprintf(str, "%f", val); }
+void xdmf_str_val(char* str, int val) { sprintf(str, "%d", val); }
+void xdmf_str_val(char* str, long int val) { sprintf(str, "%ld", val); }
+void xdmf_str_val(char* str, long long int val) { sprintf(str, "%lld", val); }
+void xdmf_str_val(char* str, unsigned long long int val) { sprintf(str, "%llu", val); }
+void xdmf_str_val(char* str, char* val) { sprintf(str, "%s", val); }
+
+template <typename T>
+void xdmf_str_val(char* str, int len, T* tab, char sep) {
+	for (int i=0; i<len; i++) {
+		xdmf_str_val(str, tab[i]);
+		if (i == len - 1) break;
+		str += strlen(str);
+		str[0] = sep;
+		str++;
+	}
+}
+
+template <typename T>
+char* xdmf_val(int len, T* tab, char sep) {
+	xdmf_str_val<T>(xdmf_string, len, tab, sep);
+	return xdmf_string;
+}
+
+template <typename T>
+char* xdmf_val(int len, T* tab) {
+	return xdmf_val<T>(len, tab, ' ');
+}
+
+
+int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool write_xdmf)
 {
 #ifdef WITH_HDF5
 	Lattice * lattice = solver->lattice;
@@ -22,8 +55,46 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what)
 
 	solver->print("writing hdf5");
 	char filename[2*STRING_LEN];
+	char * basename;
 	solver->outIterCollectiveFile(nm, ".h5", filename);
 
+	basename = filename;
+	for (char * n = filename; n[0] != '\0'; n++) {
+		if (n[0] == '/') basename = n+1;
+	}		
+
+	pugi::xml_document xdmf_doc;
+	pugi::xml_node xdmf_main = xdmf_doc.append_child("Xdmf");
+	xdmf_main.append_attribute("xmlns:xi") = "http://www.w3.org/2001/XInclude";
+	xdmf_main.append_attribute("Version") = "3.0";
+	pugi::xml_node xdmf_domain = xdmf_main.append_child("Domain");
+	pugi::xml_node xdmf_grid = xdmf_domain.append_child("Grid");
+	xdmf_grid.append_attribute("Name") = "Lattice";
+	pugi::xml_node xdmf_time = xdmf_grid.append_child("Time");
+	xdmf_time.append_attribute("Value") = solver->iter;
+	pugi::xml_node xdmf_geometry = xdmf_grid.append_child("Geometry");
+	xdmf_geometry.append_attribute("Origin") = "";
+	xdmf_geometry.append_attribute("Type") = "ORIGIN_DXDYDZ";
+	pugi::xml_node xdmf_dataitem;
+	xdmf_dataitem = xdmf_geometry.append_child("DataItem");
+	xdmf_dataitem.append_attribute("DataType") = "Float";
+	xdmf_dataitem.append_attribute("Dimensions") = "3";
+	xdmf_dataitem.append_attribute("Format") = "XML";
+	xdmf_dataitem.append_attribute("Precision") = 8;
+	{
+		double origin[3] = {0,0,0};
+		xdmf_dataitem.append_child(pugi::node_pcdata).set_value(xdmf_val(3,origin));
+	}
+	xdmf_dataitem = xdmf_geometry.append_child("DataItem");
+	xdmf_dataitem.append_attribute("DataType") = "Float";
+	xdmf_dataitem.append_attribute("Dimensions") = "3";
+	xdmf_dataitem.append_attribute("Format") = "XML";
+	xdmf_dataitem.append_attribute("Precision") = 8;
+	{
+		double spacing[3] = {0.015625, 0.015625, 0.015625};
+		xdmf_dataitem.append_child(pugi::node_pcdata).set_value(xdmf_val(3,spacing));
+	}
+	
 	size_t size;
 	lbRegion reg = lattice->region;
 	lbRegion totalreg = lattice->mpi.totalregion;
@@ -32,6 +103,7 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what)
     hid_t       file_id, dset_id;         /* file and dataset identifiers */
     hsize_t     totaldim[4];                 /* dataset dimensions */
     hsize_t     dim[4];            /* chunk dimensions */
+    hsize_t     totalpointdim[4];            /* point dimensions */
     hsize_t	offset[4];
     int         *data;                    /* pointer to data buffer to write */
     hsize_t	ones[4];	         
@@ -57,6 +129,17 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what)
     offset[2] = reg.dx;
     offset[3] = 0;
 
+    totalpointdim[0] = totalreg.nz+1;
+    totalpointdim[1] = totalreg.ny+1;
+    totalpointdim[2] = totalreg.nx+1;
+
+
+	pugi::xml_node xdmf_topology = xdmf_grid.append_child("Topology");
+	xdmf_topology.append_attribute("Dimensions") = xdmf_val(3,totalpointdim);
+	xdmf_topology.append_attribute("Type") = "3DCoRectMesh";
+
+	pugi::xml_node xdmf_attribute;
+
 	debug1("[%2d] %s dim: %lldx%lldx%lld (%lldx%lldx%lld+%lld,%lld,%lld)\n", lattice->mpi.rank,
 		filename,
 		totaldim[0], totaldim[1], totaldim[2],
@@ -75,6 +158,7 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what)
 	{
 		if (what->in("<?%s q$name ?>")) {
 			hid_t       filespace, memspace;
+			char * fieldname = "<?%s q$name ?>";
 			bool vector = <?%s ifelse(q$vector, "true", "false") ?>;
 #ifndef CALC_DOUBLE_PRECISION
 			hid_t type = H5T_NATIVE_FLOAT;
@@ -86,7 +170,7 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what)
 			filespace = H5Screate_simple(rank, totaldim, NULL); 
 			memspace  = H5Screate_simple(rank, dim, NULL); 
 			plist_id = H5Pcreate(H5P_DATASET_CREATE);
-	                    	dset_id = H5Dcreate(file_id, "<?%s q$name ?>", H5T_NATIVE_DOUBLE, filespace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
+	                    	dset_id = H5Dcreate(file_id, fieldname, H5T_NATIVE_DOUBLE, filespace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
 			H5Pclose(plist_id);
 
                     	status = H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset, ones, ones, dim);
@@ -107,11 +191,35 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what)
 			H5Dclose(dset_id);
 
 			delete[] tmp;
+			xdmf_attribute = xdmf_grid.append_child("Attribute");
+			xdmf_attribute.append_attribute("Center") = "Cell";
+			xdmf_attribute.append_attribute("ElementCell") = "";
+			xdmf_attribute.append_attribute("ElementDegree") = 0;
+			xdmf_attribute.append_attribute("ElementFamily") = "";
+			xdmf_attribute.append_attribute("ItemType") = "";
+			xdmf_attribute.append_attribute("Name") = fieldname;
+			xdmf_attribute.append_attribute("Type") = "None";
+			xdmf_dataitem = xdmf_attribute.append_child("DataItem");
+			xdmf_dataitem.append_attribute("DataType") = "Float";
+			xdmf_dataitem.append_attribute("Dimensions") = xdmf_val(rank,totaldim);
+			xdmf_dataitem.append_attribute("Format") = "HDF";
+			xdmf_dataitem.append_attribute("Precision") = 8;
+			{
+				char * str[2] = {basename, fieldname};
+				xdmf_dataitem.append_child(pugi::node_pcdata).set_value(xdmf_val(2,str,':'));
+			}
 		}
 	}
 	<?R }; ifdef(); ?>
 
     H5Fclose(file_id);
+
+
+	if (write_xdmf) {
+	    solver->outIterCollectiveFile(nm, ".xmf", filename);
+	    xdmf_doc.save_file(filename);
+	}
+
 	return 0;
 #else
 	return -1;

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -8,12 +8,13 @@
 #include "cross.h"
 #include "hdf5Lattice.h"
 #include "Global.h"
+#include "glue.hpp"
 
 #ifdef WITH_HDF5
 	#include <hdf5.h>
 #endif
 
-
+/*
 char xdmf_string[STRING_LEN*10];
 
 void xdmf_str_val(char* str, double val) { sprintf(str, "%lf", val); }
@@ -45,13 +46,29 @@ template <typename T>
 char* xdmf_val(int len, T* tab) {
 	return xdmf_val<T>(len, tab, ' ');
 }
+*/
 
+
+std::string NameXPath(const pugi::xml_node& node) {
+	std::string path;
+	if (node.parent()) {
+		path = NameXPath(node.parent());
+		path = path + "/" + node.name();
+		pugi::xml_attribute attr = node.attribute("Name");
+		if (attr) {
+			path = path + "[@Name='" + attr.value() + "']";
+		}
+	}
+	return path;
+}
 
 int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool write_xdmf)
 {
 #ifdef WITH_HDF5
+	Glue glue;
 	Lattice * lattice = solver->lattice;
 	UnitEnv * units = &solver->units;
+	double unit;
 
 	solver->print("writing hdf5");
 	char filename[2*STRING_LEN];
@@ -71,7 +88,8 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool wri
 	pugi::xml_node xdmf_grid = xdmf_domain.append_child("Grid");
 	xdmf_grid.append_attribute("Name") = "Lattice";
 	pugi::xml_node xdmf_time = xdmf_grid.append_child("Time");
-	xdmf_time.append_attribute("Value") = solver->iter;
+	unit = units->alt("1s");
+	xdmf_time.append_attribute("Value") = solver->iter / unit;
 	pugi::xml_node xdmf_geometry = xdmf_grid.append_child("Geometry");
 	xdmf_geometry.append_attribute("Origin") = "";
 	xdmf_geometry.append_attribute("Type") = "ORIGIN_DXDYDZ";
@@ -81,19 +99,14 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool wri
 	xdmf_dataitem.append_attribute("Dimensions") = "3";
 	xdmf_dataitem.append_attribute("Format") = "XML";
 	xdmf_dataitem.append_attribute("Precision") = 8;
-	{
-		double origin[3] = {0,0,0};
-		xdmf_dataitem.append_child(pugi::node_pcdata).set_value(xdmf_val(3,origin));
-	}
+	xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(" ") << 0 << 0 << 0);
 	xdmf_dataitem = xdmf_geometry.append_child("DataItem");
 	xdmf_dataitem.append_attribute("DataType") = "Float";
 	xdmf_dataitem.append_attribute("Dimensions") = "3";
 	xdmf_dataitem.append_attribute("Format") = "XML";
 	xdmf_dataitem.append_attribute("Precision") = 8;
-	{
-		double spacing[3] = {0.015625, 0.015625, 0.015625};
-		xdmf_dataitem.append_child(pugi::node_pcdata).set_value(xdmf_val(3,spacing));
-	}
+	unit = units->alt("1m");
+	xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(" ") << 1/unit << 1/unit << 1/unit);
 	
 	size_t size;
 	lbRegion reg = lattice->region;
@@ -135,7 +148,7 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool wri
 
 
 	pugi::xml_node xdmf_topology = xdmf_grid.append_child("Topology");
-	xdmf_topology.append_attribute("Dimensions") = xdmf_val(3,totalpointdim);
+	xdmf_topology.append_attribute("Dimensions") = glue(" ") << std::make_pair(totalpointdim,3);
 	xdmf_topology.append_attribute("Type") = "3DCoRectMesh";
 
 	pugi::xml_node xdmf_attribute;
@@ -176,9 +189,9 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool wri
                     	status = H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset, ones, ones, dim);
                     	if (status < 0) return H5Eprint1(stderr);
 
-			double v = units->alt("<?%s q$unit ?>");
+			unit = units->alt("<?%s q$unit ?>");
 	                <?%s q$type ?>* tmp = new <?%s q$type ?>[size];
-                        lattice->Get<?%s q$name ?>(reg, tmp, 1/v);
+                        lattice->Get<?%s q$name ?>(reg, tmp, 1/unit);
 
 			debug0("filespace: %lld memsize: %lld\n", H5Sget_select_npoints(filespace), H5Sget_select_npoints(memspace));
 			plist_id = H5Pcreate(H5P_DATASET_XFER);
@@ -193,21 +206,30 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool wri
 			delete[] tmp;
 			xdmf_attribute = xdmf_grid.append_child("Attribute");
 			xdmf_attribute.append_attribute("Center") = "Cell";
+			if (vector) xdmf_attribute.append_attribute("AttributeType") = "Vector";
 			xdmf_attribute.append_attribute("Name") = fieldname;
 			xdmf_dataitem = xdmf_attribute.append_child("DataItem");
 			xdmf_dataitem.append_attribute("DataType") = "Float";
-			xdmf_dataitem.append_attribute("Dimensions") = xdmf_val(rank,totaldim);
+			xdmf_dataitem.append_attribute("Dimensions") = glue(" ") << std::make_pair(totaldim, rank);
 			xdmf_dataitem.append_attribute("Format") = "HDF";
 			xdmf_dataitem.append_attribute("Precision") = 8;
-			{
-				char * str[2] = {basename, fieldname};
-				xdmf_dataitem.append_child(pugi::node_pcdata).set_value(xdmf_val(2,str,':'));
-			}
+			xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(":") << basename << fieldname);
+			std::string xdmf_dataitem_path = NameXPath(xdmf_dataitem);
+			xdmf_attribute = xdmf_grid.append_child("Attribute");
+			xdmf_attribute.append_attribute("Center") = "Cell";
+			if (vector) xdmf_attribute.append_attribute("AttributeType") = "Vector";
+			xdmf_attribute.append_attribute("Name") = glue("_") << fieldname << "LB";
+			xdmf_dataitem = xdmf_attribute.append_child("DataItem");
+			xdmf_dataitem.append_attribute("ItemType") = "Function";
+			xdmf_dataitem.append_attribute("Function") = glue(" ") << unit << "*" << "$0";
+			xdmf_dataitem.append_attribute("Dimensions") = glue(" ") << std::make_pair(totaldim, rank);
+			xdmf_dataitem = xdmf_dataitem.append_child("DataItem");
+			xdmf_dataitem.append_attribute("Reference") = xdmf_dataitem_path.c_str();
 		}
 	}
 	<?R }; ifdef(); ?>
 
-    H5Fclose(file_id);
+	H5Fclose(file_id);
 
 
 	if (write_xdmf) {

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -193,12 +193,7 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool wri
 			delete[] tmp;
 			xdmf_attribute = xdmf_grid.append_child("Attribute");
 			xdmf_attribute.append_attribute("Center") = "Cell";
-			xdmf_attribute.append_attribute("ElementCell") = "";
-			xdmf_attribute.append_attribute("ElementDegree") = 0;
-			xdmf_attribute.append_attribute("ElementFamily") = "";
-			xdmf_attribute.append_attribute("ItemType") = "";
 			xdmf_attribute.append_attribute("Name") = fieldname;
-			xdmf_attribute.append_attribute("Type") = "None";
 			xdmf_dataitem = xdmf_attribute.append_child("DataItem");
 			xdmf_dataitem.append_attribute("DataType") = "Float";
 			xdmf_dataitem.append_attribute("Dimensions") = xdmf_val(rank,totaldim);

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -62,7 +62,7 @@ std::string NameXPath(const pugi::xml_node& node) {
 	return path;
 }
 
-int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool write_xdmf)
+int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned long int * chunkdim_, bool write_xdmf, bool deflate)
 {
 #ifdef WITH_HDF5
 	Glue glue;
@@ -115,7 +115,8 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool wri
 
     hid_t       file_id, dset_id;         /* file and dataset identifiers */
     hsize_t     totaldim[4];                 /* dataset dimensions */
-    hsize_t     dim[4];            /* chunk dimensions */
+    hsize_t     dim[4];            /* local dimensions */
+    hsize_t     chunkdim[4];            /* local dimensions */
     hsize_t     totalpointdim[4];            /* point dimensions */
     hsize_t	offset[4];
     int         *data;                    /* pointer to data buffer to write */
@@ -123,6 +124,8 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool wri
     int         i;
     herr_t	status;
     hid_t plist_id;
+
+
 
 	ones[0] = 1;
 	ones[1] = 1;
@@ -147,20 +150,33 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool wri
     totalpointdim[2] = totalreg.nx+1;
 
 
+    MPI_Comm comm  = MPMD.local;
+    MPI_Info info  = MPI_INFO_NULL;
+
+	if (chunkdim_ != NULL) {
+	    chunkdim[0] = chunkdim_[0];
+	    chunkdim[1] = chunkdim_[1];
+	    chunkdim[2] = chunkdim_[2];
+	    chunkdim[3] = 3;
+	} else {
+	    chunkdim[0] = 1;
+	    chunkdim[1] = 1;
+	    chunkdim[2] = totaldim[3];
+	    chunkdim[3] = totaldim[3];
+	}					
+
 	pugi::xml_node xdmf_topology = xdmf_grid.append_child("Topology");
 	xdmf_topology.append_attribute("Dimensions") = glue(" ") << std::make_pair(totalpointdim,3);
 	xdmf_topology.append_attribute("Type") = "3DCoRectMesh";
 
 	pugi::xml_node xdmf_attribute;
 
-	debug1("[%2d] %s dim: %lldx%lldx%lld (%lldx%lldx%lld+%lld,%lld,%lld)\n", lattice->mpi.rank,
+	debug3("hdf5 file: %s\n   domain: %lldx%lldx%lld chunks: %lldx%lldx%lld local: %lldx%lldx%lld+%lld,%lld,%lld\n",
 		filename,
 		totaldim[0], totaldim[1], totaldim[2],
+		chunkdim[0], chunkdim[1], chunkdim[2],
 		dim[0], dim[1], dim[2],
 		offset[0], offset[1], offset[2]);
-
-    MPI_Comm comm  = MPMD.local;
-    MPI_Info info  = MPI_INFO_NULL;
 
 	plist_id = H5Pcreate(H5P_FILE_ACCESS);
 		H5Pset_fapl_mpio(plist_id, comm, info);
@@ -183,7 +199,12 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, bool wri
 			filespace = H5Screate_simple(rank, totaldim, NULL); 
 			memspace  = H5Screate_simple(rank, dim, NULL); 
 			plist_id = H5Pcreate(H5P_DATASET_CREATE);
-	                    	dset_id = H5Dcreate(file_id, fieldname, H5T_NATIVE_DOUBLE, filespace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
+			
+			status = H5Pset_chunk (plist_id, rank, chunkdim);
+			if (status < 0) return H5Eprint1(stderr);
+			if (deflate) status = H5Pset_deflate (plist_id, 6);
+			if (status < 0) return H5Eprint1(stderr);
+	                    	dset_id = H5Dcreate2(file_id, fieldname, H5T_NATIVE_DOUBLE, filespace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
 			H5Pclose(plist_id);
 
                     	status = H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset, ones, ones, dim);

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -154,10 +154,10 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 			hid_t       filespace, memspace;
 			char * fieldname = "<?%s q$name ?>";
 			bool vector = <?%s ifelse(q$vector, "true", "false") ?>;
-#ifndef CALC_DOUBLE_PRECISION
-			hid_t input_type = H5T_NATIVE_FLOAT;
-#else
+#ifdef CALC_DOUBLE_PRECISION
 			hid_t input_type = H5T_NATIVE_DOUBLE;
+#else
+			hid_t input_type = H5T_NATIVE_FLOAT;
 #endif
 			hid_t output_type;
 			int output_precision;

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -144,7 +144,7 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 
 	pugi::xml_node xdmf_attribute;
 
-	debug3("hdf5 file: %s\n   domain: %lldx%lldx%lld chunks: %lldx%lldx%lld local: %lldx%lldx%lld+%lld,%lld,%lld\n",
+	debug2("hdf5 file: %s\n   domain: %lldx%lldx%lld chunks: %lldx%lldx%lld local: %lldx%lldx%lld+%lld,%lld,%lld\n",
 		filename,
 		totaldim[0], totaldim[1], totaldim[2],
 		chunkdim[0], chunkdim[1], chunkdim[2],

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -13,6 +13,7 @@
 
 #include <hdf5.h>
 
+
 int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv units, name_set * what)
 {
 	size_t size;
@@ -21,17 +22,18 @@ int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv units, na
 	size = reg.size();
 
     hid_t       file_id, dset_id;         /* file and dataset identifiers */
-    hid_t       filespace, memspace;      /* file and memory dataspace identifiers */
-    hsize_t     dimsf[3];                 /* dataset dimensions */
-    hsize_t     chunk_dims[3];            /* chunk dimensions */
+    hsize_t     totaldim[4];                 /* dataset dimensions */
+    hsize_t     dim[4];            /* chunk dimensions */
+    hsize_t	offset[4];
     int         *data;                    /* pointer to data buffer to write */
-    hsize_t	count[2];	          /* hyperslab selection parameters */
-    hsize_t	stride[2];
-    hsize_t	block[2];
-    hsize_t	offset[3];
+    hsize_t	ones[4];	         
     int         i;
     herr_t	status;
 
+	ones[0] = 1;
+	ones[1] = 1;
+	ones[2] = 1;
+	ones[3] = 1;
 
     MPI_Comm comm  = MPMD.local;
     MPI_Info info  = MPI_INFO_NULL;
@@ -43,57 +45,57 @@ int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv units, na
 	    	file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
     	H5Pclose(plist_id);
 
-    dimsf[0] = totalreg.nz;
-    dimsf[1] = totalreg.ny;
-    dimsf[2] = totalreg.nx;
-    chunk_dims[0] = reg.nz;   
-    chunk_dims[1] = reg.ny;   
-    chunk_dims[2] = reg.nx;
+    totaldim[0] = totalreg.nz;
+    totaldim[1] = totalreg.ny;
+    totaldim[2] = totalreg.nx;
+    totaldim[3] = 3;
+    dim[0] = reg.nz;   
+    dim[1] = reg.ny;   
+    dim[2] = reg.nx;
+    dim[3] = 3;
     offset[0] = reg.dz;
     offset[1] = reg.dy;
     offset[2] = reg.dx;
+    offset[3] = 0;
 
 	printf("[%d] dim: %lldx%lldx%lld (%lldx%lldx%lld+%lld,%lld,%lld)\n", lattice->mpi.rank,
-		dimsf[0], dimsf[1], dimsf[2],
-		chunk_dims[0], chunk_dims[1], chunk_dims[2],
+		totaldim[0], totaldim[1], totaldim[2],
+		dim[0], dim[1], dim[2],
 		offset[0], offset[1], offset[2]);
 
-    filespace = H5Screate_simple(3, dimsf, NULL); 
-    memspace  = H5Screate_simple(3, chunk_dims, NULL); 
-
-    count[0] = 1;
-    count[1] = 1;
-    count[2] = 1;
-    stride[0] = 1;
-    stride[1] = 1;
-    stride[2] = 1;
-    block[0] =  chunk_dims[0];
-    block[1] =  chunk_dims[1];
-    block[2] =  chunk_dims[2];
-
-	<?R for (q in rows(Quantities)[1]) { ifdef(q$adjoint); ?>
+	<?R for (q in rows(Quantities)) { ifdef(q$adjoint); ?>
 	{
 		if (what->in("<?%s q$name ?>")) {
+			hid_t       filespace, memspace;
+			bool vector = <?%s ifelse(q$vector, "true", "false") ?>;
+#ifndef CALC_DOUBLE_PRECISION
+			hid_t type = H5T_NATIVE_FLOAT;
+#else
+			hid_t type = H5T_NATIVE_DOUBLE;
+#endif
+			int rank = 3;
+			if (vector) rank = 4;
+			filespace = H5Screate_simple(rank, totaldim, NULL); 
+			memspace  = H5Screate_simple(rank, dim, NULL); 
 			plist_id = H5Pcreate(H5P_DATASET_CREATE);
 	                    	dset_id = H5Dcreate(file_id, "<?%s q$name ?>", H5T_NATIVE_DOUBLE, filespace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
 			H5Pclose(plist_id);
 
-			hid_t filespace_ = H5Dget_space(dset_id);
-    
-                    	status = H5Sselect_hyperslab(filespace_, H5S_SELECT_SET, offset, stride, count, block);
+                    	status = H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset, ones, ones, dim);
                     	if (status < 0) return H5Eprint1(stderr);
 
 			double v = units.alt("<?%s q$unit ?>");
 	                <?%s q$type ?>* tmp = new <?%s q$type ?>[size];
                         lattice->Get<?%s q$name ?>(reg, tmp, 1/v);
 
-			printf("filespace: %lld memsize: %lld\n", H5Sget_select_npoints(filespace_), H5Sget_select_npoints(memspace));
+			printf("filespace: %lld memsize: %lld\n", H5Sget_select_npoints(filespace), H5Sget_select_npoints(memspace));
 			plist_id = H5Pcreate(H5P_DATASET_XFER);
 				H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
-				status = H5Dwrite(dset_id, H5T_NATIVE_DOUBLE, memspace, filespace_, plist_id, tmp);
+				status = H5Dwrite(dset_id, H5T_NATIVE_DOUBLE, memspace, filespace, plist_id, tmp);
 			
 			H5Pclose(plist_id);
-			H5Sclose(filespace_);
+			H5Sclose(filespace);
+			H5Sclose(memspace);
 			H5Dclose(dset_id);
 
 			delete[] tmp;
@@ -101,8 +103,6 @@ int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv units, na
 	}
 	<?R }; ifdef(); ?>
 
-    H5Sclose(filespace);
-    H5Sclose(memspace);
     H5Fclose(file_id);
 
 	return 0;

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -59,18 +59,22 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 	xdmf_geometry.append_attribute("Origin") = "";
 	xdmf_geometry.append_attribute("Type") = "ORIGIN_DXDYDZ";
 	pugi::xml_node xdmf_dataitem;
-	xdmf_dataitem = xdmf_geometry.append_child("DataItem");
-	xdmf_dataitem.append_attribute("DataType") = "Float";
-	xdmf_dataitem.append_attribute("Dimensions") = "3";
-	xdmf_dataitem.append_attribute("Format") = "XML";
-	xdmf_dataitem.append_attribute("Precision") = 8;
-	xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(" ") << 0 << 0 << 0);
-	xdmf_dataitem = xdmf_geometry.append_child("DataItem");
-	xdmf_dataitem.append_attribute("DataType") = "Float";
-	xdmf_dataitem.append_attribute("Dimensions") = "3";
-	xdmf_dataitem.append_attribute("Format") = "XML";
-	xdmf_dataitem.append_attribute("Precision") = 8;
 	unit = units->alt("1m");
+	xdmf_dataitem = xdmf_geometry.append_child("DataItem");
+	xdmf_dataitem.append_attribute("DataType") = "Float";
+	xdmf_dataitem.append_attribute("Dimensions") = "3";
+	xdmf_dataitem.append_attribute("Format") = "XML";
+	xdmf_dataitem.append_attribute("Precision") = 8;
+	if (options & HDF5_WRITE_POINT) {
+		xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(" ") << 0.5/unit << 0.5/unit << 0.5/unit);
+	} else {
+		xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(" ") << 0 << 0 << 0);
+	}
+	xdmf_dataitem = xdmf_geometry.append_child("DataItem");
+	xdmf_dataitem.append_attribute("DataType") = "Float";
+	xdmf_dataitem.append_attribute("Dimensions") = "3";
+	xdmf_dataitem.append_attribute("Format") = "XML";
+	xdmf_dataitem.append_attribute("Precision") = 8;
 	xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(" ") << 1/unit << 1/unit << 1/unit);
 	
 	size_t size;
@@ -131,7 +135,11 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 	}					
 
 	pugi::xml_node xdmf_topology = xdmf_grid.append_child("Topology");
-	xdmf_topology.append_attribute("Dimensions") = glue(" ") << std::make_pair(totalpointdim,3);
+	if (options & HDF5_WRITE_POINT) {
+		xdmf_topology.append_attribute("Dimensions") = glue(" ") << std::make_pair(totaldim,3);
+	} else {
+		xdmf_topology.append_attribute("Dimensions") = glue(" ") << std::make_pair(totalpointdim,3);
+	}
 	xdmf_topology.append_attribute("Type") = "3DCoRectMesh";
 
 	pugi::xml_node xdmf_attribute;
@@ -200,7 +208,11 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 
 			delete[] tmp;
 			xdmf_attribute = xdmf_grid.append_child("Attribute");
-			xdmf_attribute.append_attribute("Center") = "Cell";
+			if (options & HDF5_WRITE_POINT) {
+				xdmf_attribute.append_attribute("Center") = "Node";
+			} else {
+				xdmf_attribute.append_attribute("Center") = "Cell";
+			}
 			if (vector) xdmf_attribute.append_attribute("AttributeType") = "Vector";
 			xdmf_attribute.append_attribute("Name") = fieldname;
 			xdmf_dataitem = xdmf_attribute.append_child("DataItem");
@@ -212,7 +224,11 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 			std::string xdmf_dataitem_path = NameXPath(xdmf_dataitem);
 			if (options & HDF5_WRITE_LBM) {
 				xdmf_attribute = xdmf_grid.append_child("Attribute");
-				xdmf_attribute.append_attribute("Center") = "Cell";
+				if (options & HDF5_WRITE_POINT) {
+					xdmf_attribute.append_attribute("Center") = "Node";
+				} else {
+					xdmf_attribute.append_attribute("Center") = "Cell";
+				}
 				if (vector) xdmf_attribute.append_attribute("AttributeType") = "Vector";
 				xdmf_attribute.append_attribute("Name") = glue("_") << fieldname << "LB";
 				xdmf_dataitem = xdmf_attribute.append_child("DataItem");

--- a/src/hdf5Lattice.h
+++ b/src/hdf5Lattice.h
@@ -2,10 +2,10 @@
 
 	#include "Global.h"
 //	#include "LatticeContainer.h"
-	#include "Lattice.h"
+	#include "Solver.h"
 	#include "unit.h"
 
-	int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv, name_set * s);
+	int hdf5WriteLattice(const char * filename, Solver * solver, name_set * s);
 
 #endif
 #define HDF5LATTICE_H 1

--- a/src/hdf5Lattice.h
+++ b/src/hdf5Lattice.h
@@ -5,7 +5,7 @@
 	#include "Solver.h"
 	#include "unit.h"
 
-	int hdf5WriteLattice(const char * filename, Solver * solver, name_set * s);
+	int hdf5WriteLattice(const char * filename, Solver * solver, name_set * s, bool write_xdmf);
 
 #endif
 #define HDF5LATTICE_H 1

--- a/src/hdf5Lattice.h
+++ b/src/hdf5Lattice.h
@@ -5,7 +5,13 @@
 	#include "Solver.h"
 	#include "unit.h"
 
-	int hdf5WriteLattice(const char * filename, Solver * solver, name_set * s, unsigned long int* chunkdim_, bool write_xdmf, bool deflate);
+	#define HDF5_DEFLATE 0x01
+	#define HDF5_WRITE_XDMF 0x02
+	#define HDF5_WRITE_DOUBLE 0x04
+	#define HDF5_WRITE_LBM 0x08
+	#define HDF5_WRITE_POINT 0x10
+	
+	int hdf5WriteLattice(const char * filename, Solver * solver, name_set * s, unsigned long int* chunkdim_, unsigned int options);
 
 #endif
 #define HDF5LATTICE_H 1

--- a/src/hdf5Lattice.h
+++ b/src/hdf5Lattice.h
@@ -5,7 +5,7 @@
 	#include "Solver.h"
 	#include "unit.h"
 
-	int hdf5WriteLattice(const char * filename, Solver * solver, name_set * s, bool write_xdmf);
+	int hdf5WriteLattice(const char * filename, Solver * solver, name_set * s, unsigned long int* chunkdim_, bool write_xdmf, bool deflate);
 
 #endif
 #define HDF5LATTICE_H 1

--- a/src/hdf5Lattice.h
+++ b/src/hdf5Lattice.h
@@ -1,0 +1,11 @@
+#ifndef HDF5LATTICE_H
+
+	#include "Global.h"
+//	#include "LatticeContainer.h"
+	#include "Lattice.h"
+	#include "unit.h"
+
+	int hdf5WriteLattice(const char * filename, Lattice * lattice, UnitEnv, name_set * s);
+
+#endif
+#define HDF5LATTICE_H 1

--- a/src/makefile.main.Rt
+++ b/src/makefile.main.Rt
@@ -27,6 +27,7 @@ SOURCE_PLAN+=Geometry.h def.h utils.h unit.h ZoneSettings.h SyntheticTurbulence.
 SOURCE_PLAN+=RemoteForceInterface.cpp RemoteForceInterface.h RemoteForceInterface.hpp
 SOURCE_PLAN+=TCLBForceGroupCommon.h MPMD.hpp empty.cpp Particle.hpp
 SOURCE_PLAN+=BallTree.h BallTree.hpp BallTree.cpp
+SOURCE_PLAN+=hdf5Lattice.cpp hdf5Lattice.h
 
 <?R
 	h = dir("src/Handlers","[.](h|cpp)(|.Rt)$")

--- a/src/makefile.main.Rt
+++ b/src/makefile.main.Rt
@@ -28,6 +28,7 @@ SOURCE_PLAN+=RemoteForceInterface.cpp RemoteForceInterface.h RemoteForceInterfac
 SOURCE_PLAN+=TCLBForceGroupCommon.h MPMD.hpp empty.cpp Particle.hpp
 SOURCE_PLAN+=BallTree.h BallTree.hpp BallTree.cpp
 SOURCE_PLAN+=hdf5Lattice.cpp hdf5Lattice.h
+SOURCE_PLAN+=glue.hpp
 
 <?R
 	h = dir("src/Handlers","[.](h|cpp)(|.Rt)$")


### PR DESCRIPTION
I added support for writing [HDF5](https://www.hdfgroup.org/solutions/hdf5/) files, and descriptive [Xdmf](http://www.xdmf.org/index.php/Main_Page) (.xmf) files.

The HDF5 is an established standard for heavy data, with an efficient library for parallel file writing.

The Xdmf is a XML format for describing data stored in HDF5 file that most visualization software can read.
