### PR TITLE
XPath based modification

### DIFF
--- a/src/config.mk.in
+++ b/src/config.mk.in
@@ -16,7 +16,7 @@ SOURCE_CU=Global.cu Lattice.cu main.cu vtkLattice.cu vtkOutput.cu cross.cu cuda.
 SOURCE=$(SOURCE_CU)
 HEADERS=Global.h gpu_anim.h LatticeContainer.h Lattice.h Region.h vtkLattice.h vtkOutput.h cross.h gl_helper.h Dynamics.h Dynamics.hp types.h pugixml.hpp pugiconfig.hpp
 
-OBJ  = vtkOutput.o cuda.o Global.o Lattice.o vtkLattice.o cross.o pugixml.o Geometry.o def.o unit.o Solver.o SyntheticTurbulence.o Sampler.o ZoneSettings.o RemoteForceInterface.o
+OBJ  = vtkOutput.o cuda.o Global.o Lattice.o vtkLattice.o cross.o pugixml.o Geometry.o def.o unit.o Solver.o SyntheticTurbulence.o Sampler.o ZoneSettings.o RemoteForceInterface.o xpath_modification.o
 
 AOUT=main
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 //#include <unistd.h>
 
 #include "Solver.h"
+#include "xpath_modification.h"
 
 // Reads units from configure file and applies them to the solver
 void readUnits(pugi::xml_node config, Solver* solver) {
@@ -288,114 +289,8 @@ int main ( int argc, char * argv[] )
 	XMLCHILD(config, solver->configfile, "CLBConfig");
 	
 	if (argc > 2) {
-		for (int i = 2; i < argc; i++) {
-			try {
-				output("XPATH: %s\n",argv[i]);
-				pugi::xpath_node_set found = config.select_nodes(argv[i]);
-				output("XPATH: %ld things found\n", found.size());
-				i++;
-				if (i >= argc) {
-					ERROR("no operator in xpath evaluation\n");
-					return -1;
-				} else if (strcmp(argv[i], "=") == 0) {
-					i++;
-					if (i >= argc) {
-						ERROR("XPATH: No value supplied to = operator\n");
-						return -1;
-					} else if (found.size() == 0) {
-						ERROR("XPATH: Nothing selected for substitution\n");
-						return -1;
-					} else for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
-						if (it->attribute()) {
-							it->attribute().set_value(argv[i]);
-							output("XPATH: Set attr %s to \"%s\"\n", it->attribute().name(), it->attribute().value());
-						} else {
-							ERROR("XPATH: Operator = can only be used for attributes\n");
-							return -1;
-						}
-					}
-				} else if (strcmp(argv[i], "inject") == 0) {
-					i++;
-					int type = 0;	// 0 - last   - at the end of node
-							// 1 - first  - at the begining of node
-							// 2 - after  - after a node
-							// 3 - before - before a node
-					if (i >= argc) {
-						ERROR("XPATH: No value or specifier supplied to inject operator\n");
-						return -1;
-					} else if (strcmp(argv[i], "last") == 0) {
-						type = 0; i++;
-					} else if (strcmp(argv[i], "first") == 0) {
-						type = 1; i++;
-					} else if (strcmp(argv[i], "after") == 0) {
-						type = 2; i++;
-					} else if (strcmp(argv[i], "before") == 0) {
-						type = 3; i++;
-					}
-					pugi::xml_document doc;
-					pugi::xml_parse_result result;
-					if (i >= argc) {
-						ERROR("XPATH: No value supplied to inject operator\n");
-						return -1;
-					}
-					result = doc.load_string(argv[i]);
-					if (!result) {
-						ERROR("XPATH: Error while parsing inject string: %s\n", result.description());
-						return -1;
-					}
-					pugi::xml_node node = doc.first_child();
-					if (! node) {
-						ERROR("XPATH: No XML children in inject string\n");
-						return -1;
-					} else if (node.next_sibling()) {
-						ERROR("XPATH: More then one XML child in inject string\n");
-						return -1;
-					}
-					if (found.size() == 0) {
-						ERROR("XPATH: Nothing selected for injection\n");
-						return -1;
-					} else if (found.size() != 1) {
-						WARNING("XPATH: More then one thing selected for injection\n");
-					}
-					for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
-						if (it->node()) {
-							if (type == 0) {
-								it->node().append_copy(node); break;
-							} else if (type == 1) {
-								it->node().prepend_copy(node); break;
-							} else if (type == 2) {
-								it->node().parent().insert_copy_after(node, it->node()); break;
-							} else if (type == 3) {
-								it->node().parent().insert_copy_before(node, it->node()); break;
-							} else {
-								ERROR("XPATH: Unknown type (this should not happen)\n");
-							}
-						} else {
-							ERROR("XPATH: Operator 'insert' can only be used for nodes\n");
-							return -1;
-						}
-					}
-				} else if (strcmp(argv[i], "print") == 0) {
-					for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
-						if (it->node()) {
-							output("XPATH: Node: %s\n", it->node().name());
-						} else if (it->attribute()) {
-							output("XPATH: Attr: %s=\"%s\"\n", it->attribute().name(), it->attribute().value());
-						}
-					}
-				} else {
-					ERROR("Unknown operator in xpath evaluation: %s\n",argv[i]);
-					ERROR("Currently supported: =, print, insert\n");
-					return -1;
-				}
-			} catch (pugi::xpath_exception& err) {
-				ERROR("XPATH: parsing error: %s\n", err.what());
-				ERROR("XPATH: Syntax: .../main file.xml XPATH = value (spaces are important)");
-				return -1;
-			}
-		}
+		xpath_modify(config, argc-2, argv+2);
 	}
-	
 	
 	XMLCHILD(geom, config, "Geometry");
 	readUnits(config, solver);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,7 +225,7 @@ int main ( int argc, char * argv[] )
 	{
 		int count, dev;
 		CudaGetDeviceCount( &count );
-		if (argc >= 3) {
+/*		if (argc >= 3) {
                 	if (argc < 2 + solver->mpi.size) {
 				error("Not enough device numbers");
 				notice("Usage: program configfile [device number]\n");
@@ -240,10 +240,10 @@ int main ( int argc, char * argv[] )
 			#ifdef GRAPHICS
 				if (dev != 0) { error("Only device 0 can be selected for GUI program (not yet implemented)\n"); return -1; }
 			#endif
-		} else {
+		} else { */
 			CudaGetDeviceCount( &count );
 			dev = solver->mpi.rank % count;
-		}
+/*		} */
 		debug2("Selecting device %d/%d\n", dev, count);
 		CudaSetDevice( dev );
 		solver->mpi.gpu = dev;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,49 +283,109 @@ int main ( int argc, char * argv[] )
 		return -1;
 	}
 	
+	#define XMLCHILD(x,y,z) { x = y.child(z); if (!x) { error(" in %s: No \"%s\" element\n",filename,z); return -1; }}
+	pugi::xml_node config, geom, units;
+	XMLCHILD(config, solver->configfile, "CLBConfig");
+	
 	if (argc > 2) {
 		for (int i = 2; i < argc; i++) {
 			try {
 				output("XPATH: %s\n",argv[i]);
-				pugi::xpath_node_set found = solver->configfile.select_nodes(argv[i]);
+				pugi::xpath_node_set found = config.select_nodes(argv[i]);
 				output("XPATH: %ld things found\n", found.size());
 				i++;
-				if (i < argc) {
-					if (strcmp(argv[i], "=") == 0) {
-						i++;
-						if (i < argc) {
-							if (found.size() == 0) {
-								ERROR("XPATH: Nothing selected for substitution\n");
-								return -1;
-							}
-							for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
-								if (it->attribute()) {
-									it->attribute().set_value(argv[i]);
-									output("XPATH: Set attr %s to \"%s\"\n", it->attribute().name(), it->attribute().value());
-								} else {
-									ERROR("XPATH: Node selected. Can only substitute attributes\n");
-									return -1;
-								}
-							}
+				if (i >= argc) {
+					ERROR("no operator in xpath evaluation\n");
+					return -1;
+				} else if (strcmp(argv[i], "=") == 0) {
+					i++;
+					if (i >= argc) {
+						ERROR("XPATH: No value supplied to = operator\n");
+						return -1;
+					} else if (found.size() == 0) {
+						ERROR("XPATH: Nothing selected for substitution\n");
+						return -1;
+					} else for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
+						if (it->attribute()) {
+							it->attribute().set_value(argv[i]);
+							output("XPATH: Set attr %s to \"%s\"\n", it->attribute().name(), it->attribute().value());
 						} else {
-							ERROR("XPATH: No value supplied to = operator\n");
+							ERROR("XPATH: Operator = can only be used for attributes\n");
 							return -1;
 						}
-					} else if (strcmp(argv[i], "print") == 0) {
-						for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
-							if (it->node()) {
-								output("XPATH: Node: %s\n", it->node().name());
-							} else if (it->attribute()) {
-								output("XPATH: Attr: %s=\"%s\"\n", it->attribute().name(), it->attribute().value());
-							}
-						}
-					} else {
-						ERROR("Unknown operator in xpath evaluation: %s\n",argv[i]);
-						ERROR("Currently supported: =, print\n");
+					}
+				} else if (strcmp(argv[i], "inject") == 0) {
+					i++;
+					int type = 0;	// 0 - last   - at the end of node
+							// 1 - first  - at the begining of node
+							// 2 - after  - after a node
+							// 3 - before - before a node
+					if (i >= argc) {
+						ERROR("XPATH: No value or specifier supplied to inject operator\n");
+						return -1;
+					} else if (strcmp(argv[i], "last") == 0) {
+						type = 0; i++;
+					} else if (strcmp(argv[i], "first") == 0) {
+						type = 1; i++;
+					} else if (strcmp(argv[i], "after") == 0) {
+						type = 2; i++;
+					} else if (strcmp(argv[i], "before") == 0) {
+						type = 3; i++;
+					}
+					pugi::xml_document doc;
+					pugi::xml_parse_result result;
+					if (i >= argc) {
+						ERROR("XPATH: No value supplied to inject operator\n");
 						return -1;
 					}
+					result = doc.load_string(argv[i]);
+					if (!result) {
+						ERROR("XPATH: Error while parsing inject string: %s\n", result.description());
+						return -1;
+					}
+					pugi::xml_node node = doc.first_child();
+					if (! node) {
+						ERROR("XPATH: No XML children in inject string\n");
+						return -1;
+					} else if (node.next_sibling()) {
+						ERROR("XPATH: More then one XML child in inject string\n");
+						return -1;
+					}
+					if (found.size() == 0) {
+						ERROR("XPATH: Nothing selected for injection\n");
+						return -1;
+					} else if (found.size() != 1) {
+						WARNING("XPATH: More then one thing selected for injection\n");
+					}
+					for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
+						if (it->node()) {
+							if (type == 0) {
+								it->node().append_copy(node); break;
+							} else if (type == 1) {
+								it->node().prepend_copy(node); break;
+							} else if (type == 2) {
+								it->node().parent().insert_copy_after(node, it->node()); break;
+							} else if (type == 3) {
+								it->node().parent().insert_copy_before(node, it->node()); break;
+							} else {
+								ERROR("XPATH: Unknown type (this should not happen)\n");
+							}
+						} else {
+							ERROR("XPATH: Operator 'insert' can only be used for nodes\n");
+							return -1;
+						}
+					}
+				} else if (strcmp(argv[i], "print") == 0) {
+					for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
+						if (it->node()) {
+							output("XPATH: Node: %s\n", it->node().name());
+						} else if (it->attribute()) {
+							output("XPATH: Attr: %s=\"%s\"\n", it->attribute().name(), it->attribute().value());
+						}
+					}
 				} else {
-					ERROR("no operator in xpath evaluation\n");
+					ERROR("Unknown operator in xpath evaluation: %s\n",argv[i]);
+					ERROR("Currently supported: =, print, insert\n");
 					return -1;
 				}
 			} catch (pugi::xpath_exception& err) {
@@ -337,9 +397,6 @@ int main ( int argc, char * argv[] )
 	}
 	
 	
-	#define XMLCHILD(x,y,z) { x = y.child(z); if (!x) { error(" in %s: No \"%s\" element\n",filename,z); return -1; }}
-	pugi::xml_node config, geom, units;
-	XMLCHILD(config, solver->configfile, "CLBConfig");
 	XMLCHILD(geom, config, "Geometry");
 	readUnits(config, solver);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,7 +289,8 @@ int main ( int argc, char * argv[] )
 	XMLCHILD(config, solver->configfile, "CLBConfig");
 	
 	if (argc > 2) {
-		xpath_modify(config, argc-2, argv+2);
+		int status = xpath_modify(config, argc-2, argv+2);
+		if (status != 0) return status;
 	}
 	
 	XMLCHILD(geom, config, "Geometry");

--- a/src/makefile.main.Rt
+++ b/src/makefile.main.Rt
@@ -27,6 +27,7 @@ SOURCE_PLAN+=Geometry.h def.h utils.h unit.h ZoneSettings.h SyntheticTurbulence.
 SOURCE_PLAN+=RemoteForceInterface.cpp RemoteForceInterface.h RemoteForceInterface.hpp
 SOURCE_PLAN+=TCLBForceGroupCommon.h MPMD.hpp empty.cpp Particle.hpp
 SOURCE_PLAN+=BallTree.h BallTree.hpp BallTree.cpp
+SOURCE_PLAN+=xpath_modification.cpp xpath_modification.h
 
 <?R
 	h = dir("src/Handlers","[.](h|cpp)(|.Rt)$")

--- a/src/xpath_modification.cpp
+++ b/src/xpath_modification.cpp
@@ -1,0 +1,113 @@
+#include "Global.h"
+#include "xpath_modification.h"
+
+int xpath_modify(pugi::xml_node config, int argc, char * argv[] ) {
+    for (int i = 0; i < argc; i++) {
+            try {
+                    output("XPATH: %s\n",argv[i]);
+                    pugi::xpath_node_set found = config.select_nodes(argv[i]);
+                    output("XPATH: %ld things found\n", found.size());
+                    i++;
+                    if (i >= argc) {
+                            ERROR("no operator in xpath evaluation\n");
+                            return -1;
+                    } else if (strcmp(argv[i], "=") == 0) {
+                            i++;
+                            if (i >= argc) {
+                                    ERROR("XPATH: No value supplied to = operator\n");
+                                    return -1;
+                            } else if (found.size() == 0) {
+                                    ERROR("XPATH: Nothing selected for substitution\n");
+                                    return -1;
+                            } else for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
+                                    if (it->attribute()) {
+                                            it->attribute().set_value(argv[i]);
+                                            output("XPATH: Set attr %s to \"%s\"\n", it->attribute().name(), it->attribute().value());
+                                    } else {
+                                            ERROR("XPATH: Operator = can only be used for attributes\n");
+                                            return -1;
+                                    }
+                            }
+                    } else if (strcmp(argv[i], "inject") == 0) {
+                            i++;
+                            int type = 0;	// 0 - last   - at the end of node
+                                            // 1 - first  - at the begining of node
+                                            // 2 - after  - after a node
+                                            // 3 - before - before a node
+                            if (i >= argc) {
+                                    ERROR("XPATH: No value or specifier supplied to inject operator\n");
+                                    return -1;
+                            } else if (strcmp(argv[i], "last") == 0) {
+                                    type = 0; i++;
+                            } else if (strcmp(argv[i], "first") == 0) {
+                                    type = 1; i++;
+                            } else if (strcmp(argv[i], "after") == 0) {
+                                    type = 2; i++;
+                            } else if (strcmp(argv[i], "before") == 0) {
+                                    type = 3; i++;
+                            }
+                            pugi::xml_document doc;
+                            pugi::xml_parse_result result;
+                            if (i >= argc) {
+                                    ERROR("XPATH: No value supplied to inject operator\n");
+                                    return -1;
+                            }
+                            result = doc.load_string(argv[i]);
+                            if (!result) {
+                                    ERROR("XPATH: Error while parsing inject string: %s\n", result.description());
+                                    return -1;
+                            }
+                            pugi::xml_node node = doc.first_child();
+                            if (! node) {
+                                    ERROR("XPATH: No XML children in inject string\n");
+                                    return -1;
+                            } else if (node.next_sibling()) {
+                                    ERROR("XPATH: More then one XML child in inject string\n");
+                                    return -1;
+                            }
+                            if (found.size() == 0) {
+                                    ERROR("XPATH: Nothing selected for injection\n");
+                                    return -1;
+                            } else if (found.size() != 1) {
+                                    WARNING("XPATH: More then one thing selected for injection\n");
+                            }
+                            for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
+                                    if (it->node()) {
+                                            if (type == 0) {
+                                                    it->node().append_copy(node); break;
+                                            } else if (type == 1) {
+                                                    it->node().prepend_copy(node); break;
+                                            } else if (type == 2) {
+                                                    it->node().parent().insert_copy_after(node, it->node()); break;
+                                            } else if (type == 3) {
+                                                    it->node().parent().insert_copy_before(node, it->node()); break;
+                                            } else {
+                                                    ERROR("XPATH: Unknown type (this should not happen)\n");
+                                            }
+                                    } else {
+                                            ERROR("XPATH: Operator 'insert' can only be used for nodes\n");
+                                            return -1;
+                                    }
+                            }
+                    } else if (strcmp(argv[i], "print") == 0) {
+                            for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
+                                    if (it->node()) {
+                                            output("XPATH: Node: %s\n", it->node().name());
+                                    } else if (it->attribute()) {
+                                            output("XPATH: Attr: %s=\"%s\"\n", it->attribute().name(), it->attribute().value());
+                                    }
+                            }
+                    } else {
+                            ERROR("Unknown operator in xpath evaluation: %s\n",argv[i]);
+                            ERROR("Currently supported: =, print, insert\n");
+                            return -1;
+                    }
+            } catch (pugi::xpath_exception& err) {
+                    ERROR("XPATH: parsing error: %s\n", err.what());
+                    ERROR("XPATH: Syntax: .../main file.xml XPATH = value (spaces are important)");
+                    return -1;
+            }
+    }
+}
+
+

--- a/src/xpath_modification.cpp
+++ b/src/xpath_modification.cpp
@@ -28,7 +28,7 @@ int xpath_modify(pugi::xml_node config, int argc, char * argv[] ) {
                                             return -1;
                                     }
                             }
-                    } else if (strcmp(argv[i], "inject") == 0) {
+                    } else if ((strcmp(argv[i], "inject") == 0) || (strcmp(argv[i], "insert") == 0)) {
                             i++;
                             int type = 0;	// 0 - last   - at the end of node
                                             // 1 - first  - at the begining of node

--- a/src/xpath_modification.cpp
+++ b/src/xpath_modification.cpp
@@ -108,6 +108,7 @@ int xpath_modify(pugi::xml_node config, int argc, char * argv[] ) {
                     return -1;
             }
     }
+    return 0;
 }
 
 

--- a/src/xpath_modification.cpp
+++ b/src/xpath_modification.cpp
@@ -31,7 +31,7 @@ int xpath_modify(pugi::xml_node config, int argc, char * argv[] ) {
                                     if (add_attribute == NULL) {
                                             if (attr) {
                                                     attr.set_value(argv[i]);
-                                                    output("XPATH: Set attr %s to \"%s\"\n", attr.name(), attr.value());
+                                                    output("XPATH: Set attr %s to \"%s\" in <%s />\n", attr.name(), attr.value(), it->parent().name());
                                             } else error = true;
                                     } else {
                                             pugi::xml_node node = it->node();
@@ -115,6 +115,16 @@ int xpath_modify(pugi::xml_node config, int argc, char * argv[] ) {
                                             return -1;
                                     }
                             }
+                    } else if (strcmp(argv[i], "delete") == 0) {
+                            for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
+                                    if (it->node()) {
+                                            output("XPATH: Removed node: <%s />\n", it->node().name());
+                                            it->parent().remove_child(it->node());
+                                    } else if (it->attribute()) {
+                                            output("XPATH: Removed attribute: %s = %s\n", it->attribute().name(), it->attribute().value());
+                                            it->parent().remove_attribute(it->attribute());
+                                    }
+                            }
                     } else if (strcmp(argv[i], "print") == 0) {
                             for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
                                     if (it->node()) {
@@ -125,7 +135,7 @@ int xpath_modify(pugi::xml_node config, int argc, char * argv[] ) {
                             }
                     } else {
                             ERROR("Unknown operator in xpath evaluation: %s\n",argv[i]);
-                            ERROR("Currently supported: =, print, insert\n");
+                            ERROR("Currently supported: =, print, insert/inject, delete\n");
                             return -1;
                     }
             } catch (pugi::xpath_exception& err) {

--- a/src/xpath_modification.h
+++ b/src/xpath_modification.h
@@ -1,0 +1,6 @@
+#ifndef XPATH_MOD_H
+#define XPATH_MOD_H
+#include "pugixml.hpp"
+    int xpath_modify(pugi::xml_node config, int argc, char * argv[] );
+
+#endif


### PR DESCRIPTION
# Description
I added support for adding small (and big) modifications to the xml which is being run on the command line.

## How it works
The syntax quite simple. For instance if you want to set the `output` attribute of your case, that would be:
```bash
CLB/d2q9/main file.xml @output = "test/"
```

Where `@output` can be any [XPath](https://en.wikipedia.org/wiki/XPath) expression matching some attributes. For instance:
```bash
CLB/d2q9/main file.xml //@output = "test/"
```
Would substitute `output` attribute with `test/` *everywhere* in the case file. With this you can do:
```bash
CLB/d2q9/main file.xml //@Viscosity = "0.16"
```
To run your case with a different Viscosity

## Notice
**The xml file (with all modification) is saved in the output directory with all the results for later inspection**

## Operators
I implemented three operators: `=`, `insert` and `print`. One can add new operators later on.

### `print` operator
Just prints what the XPath maches:
#### Examples
```bash
# print all Params attributes:
CLB/d2q9/main file.xml //Params/@* print
```

### `=` operator
Substitutes the matching attributes with `[xpath expression] = [value]` or add attribute to nodes with `[xpath expression] @[attribute name] = [value]`.
#### Examples
```bash
# change output path everywhere in the case file
CLB/d2q9/main file.xml //@output = "test/"
# change viscosity
CLB/d2q9/main file.xml //@Viscosity = "test/"
# change the length of domain
CLB/d2q9/main file.xml Geometry/@nx = "128"
# select field to export in VTK
CLB/d2q9/main file.xml //VTK/@what = "U,Rho"
# select field to export in VTK (even if the attribute didn't exist)
CLB/d2q9/main file.xml //VTK @what = "U,Rho"
```

### `insert` operator
Inserts an arbitrary piece of XML code into the case. You can specify where it should be placed with:

specifier | placement
--- | ---
`after` | after the selected node (sibling)
`before` | before the selected node (sibling)
`last` (default) | at the end of the selected node (child)
`first` | at the beginning of the selected node (child)

#### Examples
```bash
# run some more iterations at the end
CLB/d2q9/main file.xml . insert '<Solve Iterations="100"/>'
# add some parameters
CLB/d2q9/main file.xml Model insert '<Params Viscosity="10"/>'
# add a Log output
CLB/d2q9/main file.xml Model insert after '<Log Iterations="10"/>'
# add VTK output before every Solve
CLB/d2q9/main file.xml //Solve insert before '<VTK/>'
```

### `delete` operator
Deletes what the XPath maches.
#### Examples
```bash
# Delete all VTK output:
CLB/d2q9/main file.xml //VTK delete
```
