### PR TITLE
Correcting the device selection

### DIFF
--- a/src/makefile.main.Rt
+++ b/src/makefile.main.Rt
@@ -30,6 +30,7 @@ SOURCE_PLAN+=BallTree.h BallTree.hpp BallTree.cpp
 SOURCE_PLAN+=xpath_modification.cpp xpath_modification.h
 SOURCE_PLAN+=hdf5Lattice.cpp hdf5Lattice.h
 SOURCE_PLAN+=glue.hpp
+SOURCE_PLAN+=mpitools.hpp
 
 <?R
 	h = dir("src/Handlers","[.](h|cpp)(|.Rt)$")

--- a/src/mpitools.hpp
+++ b/src/mpitools.hpp
@@ -1,0 +1,63 @@
+#ifndef MPITOOLS_H
+#define MPITOOLS_H
+
+
+#include <mpi.h>
+#include <string>
+
+namespace mpitools {
+
+inline std::string MPI_Bcast(const std::string& str, int root, MPI_Comm comm) {
+        size_t size = str.size();
+        MPI_Bcast(&size, 1, MPI_UNSIGNED_LONG, root, comm);
+        char * buf = new char[size+1];
+        strcpy(buf, str.c_str());
+        MPI_Bcast(buf, size+1, MPI_CHAR, root, comm);
+        std::string ret(buf,size);
+        delete[] buf;
+        return ret;
+}
+
+inline std::string MPI_Nodename(MPI_Comm comm) {
+        int cpname_len;
+        char cpname[MPI_MAX_PROCESSOR_NAME];
+        MPI_Get_processor_name(cpname, &cpname_len);
+        return std::string(cpname, cpname_len);
+}
+
+inline int MPI_Rank(MPI_Comm comm) {
+    int rank;
+    MPI_Comm_rank(comm, &rank);
+    return rank;
+}
+
+inline int MPI_Size(MPI_Comm comm) {
+    int size;
+    MPI_Comm_size(comm, &size);
+    return size;
+}
+
+inline MPI_Comm MPI_Split(const std::string& str, MPI_Comm comm) {
+        int rank = MPI_Rank(comm);
+        int size = MPI_Size(comm);
+        int wrank = rank;
+        int firstrank = 0;
+        int color = -1;
+        int i = 0;
+        while (true) {
+                std::string otherstr = MPI_Bcast(str, firstrank, comm);
+                if (otherstr == str) {
+                        wrank = size;
+                        color = i;
+                }
+                i++;
+                MPI_Allreduce(&wrank, &firstrank, 1, MPI_INT, MPI_MIN, comm );
+                if (firstrank >= size) break;
+        }
+        MPI_Comm newcomm;
+        MPI_Comm_split(comm, color, rank, &newcomm);
+        return newcomm;
+}
+
+};
+#endif


### PR DESCRIPTION
# Description
## Problem
To select the GPU, the code assumes that:
- the MPI ranks are distributive in consecutive chunks
- all nodes have the same number of GPUs

And calculates the GPU id as `dev = rank % count`. This doesn't work if any of the assumptions fail.

## Solution
Now the main function will split the MPI comm on the name of the node, and uses the local rank (the rank with respect to the node) as the device number.

# Notes
## Backwards compatibility
This change doesn't affect the device selection if the assumptions were fulfilled. But will fail if one over-subscribes GPUs (see below)

## Over-subscription of GPUs
The code will fail with an error if multiple ranks will select the same gpu (this is called oversubscription). If you want to oversubscribe, add `oversubscribe_gpu="true"` to the `<CLBConfig/>`.

