### PR TITLE
Fixing bug in Units

### DIFF
--- a/src/Global.cpp.Rt
+++ b/src/Global.cpp.Rt
@@ -185,7 +185,7 @@ int special_print(FILE* f, char * rank, int level, int color, int lines, char * 
 }
 
 
-int myprint(int level, const char *fmt, ...)
+int myprint(int level, int all, const char *fmt, ...)
 {
     if (level < D_print_level) return 0;
     va_list args;
@@ -193,7 +193,7 @@ int myprint(int level, const char *fmt, ...)
     static char buf[100*OUTPUT_LINE_LEN];
     vsprintf(buf, fmt, args);
     char* rank="";
-    if (level < D_only_root_level) {
+    if ((level < D_only_root_level) && (!all)) {
       if (D_MPI_RANK != 0) return 0;
     } else {
       rank = D_str_rank;

--- a/src/Global.h.Rt
+++ b/src/Global.h.Rt
@@ -102,20 +102,21 @@ for (m in Margin) { ?>
     extern int D_MPI_RANK;
     extern int D_TERMINAL;
 
-    int myprint(int level, const char *fmt, ...);
+    int myprint(int level, int all, const char *fmt, ...);
     int InitPrint(int print_level, int only_root_level, int error_level);
-    #define dprint(x, ...) myprint(x, __VA_ARGS__)
-    #define debug0(...) DEBUG0(myprint(0, __VA_ARGS__)) // 0-level Debug
-    #define debug1(...) DEBUG1(myprint(1, __VA_ARGS__)) // 1-level Debug
-    #define debug2(...) DEBUG2(myprint(2, __VA_ARGS__)) // 2-level Debug
-    #define debug3(...) DEBUG3(myprint(3, __VA_ARGS__)) // Output
-    #define debug4(...) myprint(4, __VA_ARGS__) // Notice
-    #define debug5(...) myprint(5, __VA_ARGS__) // Important Notice
-    #define debug6(...) myprint(6, __VA_ARGS__) // Warning
-    #define debug7(...) myprint(7, __VA_ARGS__) // Important Warning
-    #define debug8(...) myprint(8, __VA_ARGS__) // Error
-    #define debug9(...) myprint(9, __VA_ARGS__) // Fatal Error
+    #define dprint(x, ...) myprint(x, 0, __VA_ARGS__)
+    #define debug0(...) DEBUG0(myprint(0, 0, __VA_ARGS__)) // 0-level Debug
+    #define debug1(...) DEBUG1(myprint(1, 0, __VA_ARGS__)) // 1-level Debug
+    #define debug2(...) DEBUG2(myprint(2, 0, __VA_ARGS__)) // 2-level Debug
+    #define debug3(...) DEBUG3(myprint(3, 0, __VA_ARGS__)) // Output
+    #define debug4(...) myprint(4, 0, __VA_ARGS__) // Notice
+    #define debug5(...) myprint(5, 0, __VA_ARGS__) // Important Notice
+    #define debug6(...) myprint(6, 0, __VA_ARGS__) // Warning
+    #define debug7(...) myprint(7, 0, __VA_ARGS__) // Important Warning
+    #define debug8(...) myprint(8, 0, __VA_ARGS__) // Error
+    #define debug9(...) myprint(9, 0, __VA_ARGS__) // Fatal Error
     
+    #define output_all(...) DEBUG3(myprint(3, -1, __VA_ARGS__))
     #define output(...) debug3(__VA_ARGS__)    
     #define notice(...) debug4(__VA_ARGS__)    
     #define NOTICE(...) debug5(__VA_ARGS__)    

--- a/src/cross.h
+++ b/src/cross.h
@@ -86,6 +86,7 @@
 
     #define CudaSetDevice(a__) HANDLE_ERROR( cudaSetDevice( a__ ) )
     #define CudaGetDeviceCount(a__) HANDLE_ERROR( cudaGetDeviceCount( a__ ) )
+    #define CudaDeviceReset() HANDLE_ERROR( cudaDeviceReset( ) )
 
 //    cudaError_t cudaPreAlloc(void ** ptr, size_t size);
 //    cudaError_t cudaAllocFinalize();
@@ -207,6 +208,7 @@
 
     #define CudaSetDevice(a__) CpuSize.x=1;CpuSize.y=1;CpuSize.z=1;
     #define CudaGetDeviceCount(a__) *a__ = 1;
+    #define CudaDeviceReset()
 
     #define RunKernelMaxThreads 1
     extern uint3 CpuBlock;

--- a/src/glue.hpp
+++ b/src/glue.hpp
@@ -11,6 +11,8 @@ private:
     std::stringstream s;
     std::string sep;
     std::string val;
+    std::string begin;
+    std::string end;
     bool empty;
 public:
     inline Glue() {
@@ -18,9 +20,19 @@ public:
         s << std::scientific;
         empty = true;
     }
+    inline Glue(std::string sep_, std::string begin_="", std::string end_="") : sep(sep_), begin(begin_), end(end_) {
+        s << std::setprecision(14);
+        s << std::scientific;
+        empty = true;
+    }
     inline Glue& operator () (std::string sep_ = "") {
         s.str(std::string());
         sep = sep_;
+        empty = true;
+        return *this;
+    }
+    inline Glue& clear() {
+        s.str(std::string());
         empty = true;
         return *this;
     }
@@ -36,12 +48,15 @@ public:
         empty = false;
         return *this;
     }
+    inline const std::string& str () {
+        val = begin + s.str() + end;
+        return val;
+    }
     inline const char* c_str () {
-        val = s.str();
-        return val.c_str();
+        return this->str().c_str();
     }
     inline operator const char* () {
-        return this->c_str();
+        return this->str().c_str();
     }
 };
 

--- a/src/gpu_anim.h
+++ b/src/gpu_anim.h
@@ -38,14 +38,6 @@ struct GPUAnimBitmap {
         dataBlock = d;
         clickDrag = NULL;
         move = NULL;
-        // first, find a CUDA device and set it to graphic interop
-        cudaDeviceProp  prop;
-        int dev;
-        memset( &prop, 0, sizeof( cudaDeviceProp ) );
-        prop.major = 1;
-        prop.minor = 0;
-        HANDLE_ERROR( cudaChooseDevice( &dev, &prop ) );
-        cudaGLSetGLDevice( dev );
 
         // a bug in the Windows GLUT implementation prevents us from
         // passing zero arguments to glutInit()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -325,7 +325,7 @@ int main ( int argc, char * argv[] )
 
 	// After the configfile comes the numbers of GPU selected for each processor (starting with 0)
 	{
-		#ifdef CROSS_GPU
+		#ifndef CROSS_CPU
 			int count, dev;
 			CudaGetDeviceCount( &count );
 			{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -347,12 +347,13 @@ int main ( int argc, char * argv[] )
 				}
 				dev = dev % count;
 			}
-			debug2("Selecting device %d/%d\n", dev, count);
+			output_all("Selecting device %d/%d\n", dev, count);
 			CudaSetDevice( dev );
 			solver->mpi.gpu = dev;
 			debug2("Initializing device\n");
 			cudaFree(0);
 		#else
+			output_all("Running on CPU\n");
 			CudaSetDevice(0);
 			solver->mpi.gpu = 0;
 		#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 #include <ctime>
-
+#include "glue.hpp"
 // for isatty
 //#include <unistd.h>
 
@@ -36,6 +36,7 @@ int readUnits(pugi::xml_node config, Solver* solver) {
 		warning("No \"Units\" element in config file\n");
 		return 0;
 	}
+	int i=1;
 	for (pugi::xml_node node = set.child("Param"); node; node = node.next_sibling("Param")) {
 	        std::string par, value, gauge;
 		pugi::xml_attribute attr;
@@ -54,9 +55,10 @@ int readUnits(pugi::xml_node config, Solver* solver) {
 			return -1;
 		}
 		attr = node.attribute("name");
-		if (attr) par = attr.value(); else par = "unnamed";
+		if (attr) par = attr.value(); else par = (Glue() << "unnamed" << i).str();
 		debug2("Units: %s = %s = %s\n", par.c_str(), val.c_str(), gauge.c_str());
 		solver->setUnit(par, value, gauge);
+		i++;
 	}
 	solver->Gauge();
 	return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -414,6 +414,7 @@ int main ( int argc, char * argv[] )
 		output("Total duration: %lf s = %lf min = %lf h\n", duration, duration / 60, duration /60/60);
 	}
 	delete solver;
+	CudaDeviceReset();
 	MPI_Finalize();
 	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -268,6 +268,7 @@ int main ( int argc, char * argv[] )
                     	config.append_attribute("permissive").set_value("true");
                     	for (pugi::xpath_node_set::const_iterator it = found.begin(); it != found.end(); ++it) {
 				pugi::xml_node node = it->node();
+				pugi::xml_node after = node;
 				std::string gauge = "";
 				pugi::xml_attribute gauge_attr = node.attribute("gauge");
 				if (gauge_attr) gauge = gauge_attr.value();
@@ -281,7 +282,8 @@ int main ( int argc, char * argv[] )
                 		                zone = par.substr(i+1);
 		                                par = par.substr(0,i);
 					}
-					pugi::xml_node param = node.parent().insert_child_after("Param", node);
+					pugi::xml_node param = node.parent().insert_child_after("Param", after);
+					after = param;
 					param.append_attribute("name").set_value(par.c_str());
 					param.append_attribute("value").set_value(attr.value());
 					if (zone != "") param.append_attribute("zone").set_value(zone.c_str());


### PR DESCRIPTION
Fixed:
- an error in treatment of `<Param/>` elements without `name` attribute in `<Units/>`. The problem relates to new syntax introduced in #241 
- the wrong order of `<Param/>` elements generated from attributes. The problem relates to new syntax introduced in #241 
- the lack of device reset, which affects sometimes the profiling done with `nvprof`