### PR TITLE
MPI_Attr_get is superseded by MPI_Comm_get_attr

### DIFF
--- a/src/Handlers/cbHDF5.cpp
+++ b/src/Handlers/cbHDF5.cpp
@@ -23,7 +23,7 @@ int cbHDF5::Init () {
 		if (deflate) options = options | HDF5_DEFLATE;
 		bool write_xdmf = true;
 		attr = node.attribute("write_xdmf");
-		if (attr) write_xdmf = attr.as_bool()
+		if (attr) write_xdmf = attr.as_bool();
                 if (write_xdmf) options = options | HDF5_WRITE_XDMF;
 		bool point_data = false;
 		attr = node.attribute("point_data");

--- a/src/MPMD.hpp
+++ b/src/MPMD.hpp
@@ -158,7 +158,7 @@ public:
 
       {
          int *universe_sizep, flag;
-         MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
+         MPI_Comm_get_attr(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          if (!flag) { 
            universe_size = 0; // LCOV_EXCL_LINE
          } else universe_size = *universe_sizep;


### PR DESCRIPTION
MPI_Attr_get is superseded by MPI_Comm_get_attr.

http://www.mpich.org/static//docs/v3.0.x/www3/MPI_Attr_get.html
https://www.mpi-forum.org/docs/mpi-3.1/mpi31-report/node34.htm

For those who care about warnings:

```
[prometheus][plgmuaddieb@login01 GG_TCLB]$ p/make d2q9
Running make on 12 cores
salloc: Pending job allocation 17101469
salloc: job 17101469 queued and waiting for resources
salloc: job 17101469 has been allocated resources
salloc: Granted job allocation 17101469
salloc: Waiting for resource configuration
salloc: Nodes p0701 are ready for job
module purge... OK
module load plgrid/apps/r/3.4.4... OK
module load plgrid/apps/cuda... OK
module load plgrid/apps/r/3.4.4... OK
module load plgrid/tools/openmpi/3.0.0-gcc-4.9.2... OK
module load plgrid/apps/cuda/9.0... OK
[login01.pro.cyfronet.pl:20803] DONE
  RT         makefile.main
  RT         CLB/d2q9/Global.cpp
  RT         CLB/d2q9/Lattice.cu
  RT         CLB/d2q9/vtkLattice.cpp
  RT         CLB/d2q9/cuda.cu
  RT         CLB/d2q9/LatticeContainer.inc.cpp
  RT         CLB/d2q9/LatticeAccess.inc.cpp
  RT         CLB/d2q9/Dynamics.c (model)
  RT         CLB/d2q9/Solver.cpp
  RT         CLB/d2q9/Geometry.cpp
  RT         CLB/d2q9/def.cpp
  RT         CLB/d2q9/Sampler.cpp
  CP         CLB/d2q9/main.cpp
  RT         CLB/d2q9/Global.h
  RT         CLB/d2q9/LatticeContainer.h
  RT         CLB/d2q9/Lattice.h
  CP         CLB/d2q9/cross.h
  RT         CLB/d2q9/Dynamics.h
  RT         CLB/d2q9/Consts.h
  RT         CLB/d2q9/Solver.h
  CP         CLB/d2q9/MPMD.hpp
  CP         CLB/d2q9/xpath_modification.cpp
  CP         CLB/d2q9/xpath_modification.h
  RT         CLB/d2q9/hdf5Lattice.cpp
  CP         CLB/d2q9/glue.hpp
  CP         CLB/d2q9/mpitools.hpp
  RT         CLB/d2q9/Handlers/acObjective.cpp
  RT         CLB/d2q9/Handlers/acOptimize.cpp
  RT         CLB/d2q9/Handlers/acParam.cpp
  CP         CLB/d2q9/Handlers/acParam.h
  RT         CLB/d2q9/Handlers/acThreshold.cpp
  RT         CLB/d2q9/Handlers/acThresholdNow.cpp
  CP         CLB/d2q9/Handlers/BSpline.cpp
  CP         CLB/d2q9/Handlers/cbCatalyst.cpp
  RT         CLB/d2q9/Handlers/cbFailcheck.cpp
  CP         CLB/d2q9/Handlers/cbHDF5.cpp
  RT         CLB/d2q9/Handlers/cbPID.cpp
  RT         CLB/d2q9/Handlers/cbRunR.cpp
Warning message:
In readLines(f) : incomplete final line found on 'src/hdf5Lattice.cpp.Rt'
  RT         CLB/d2q9/Handlers/cbStop.cpp
  CP         CLB/d2q9/Handlers/cbTXT.cpp
  CP         CLB/d2q9/Handlers/cbTXT.h
  RT         CLB/d2q9/Handlers/conControl.cpp
  CP         CLB/d2q9/Handlers/conControl.h
  RT         CLB/d2q9/Handlers/conFieldParameter.cpp
  RT         CLB/d2q9/Handlers/IfContainer.cpp
  RT         CLB/d2q9/Handlers/IfContainer.h
  RT         CLB/d2q9/Handlers/OptimalControl.cpp
  RT         CLB/d2q9/Handlers/OptimalControlSecond.cpp
  CP         CLB/d2q9/Handlers/vHandler.h
  RT         CLB/d2q9/SUMMARY
make: Circular CLB/d2q9/makefile <- CLB/d2q9/makefile dependency dropped.
  RT         CLB/d2q9/Catalyst.cpp
  RT         CLB/d2q9//dictionary.h
  SP-CONST   CLB/d2q9/Dynamics_sp.c
  MKHEADERS  CLB/d2q9/Dynamics.c
  AUTO-DEP   CLB/d2q9/dep.mk
  RT         CLB/d2q9/makefile
make[1]: Entering directory `/net/people/plgmuaddieb/GG_TCLB/CLB/d2q9'
  G++        empty.cpp
  G++        Handlers/NullHandler.cpp
  G++        vtkOutput.cpp
  G++        Global.cpp
  G++        def.cpp
  G++        unit.cpp
  G++        SyntheticTurbulence.cpp
  G++        Sampler.cpp
  G++        ZoneSettings.cpp
  G++        xpath_modification.cpp
In file included from empty.cpp:1:0:
MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  NVCC       cross.cu
  G++        Geometry.cpp
In file included from Global.h:26:0,
                 from SyntheticTurbulence.h:5,
                 from SyntheticTurbulence.cpp:1:
MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Global.h:26:0,
                 from Global.cpp:15:
MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Global.h:26:0,
                 from ZoneSettings.cpp:2:
MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  NVCC       Lattice.cu
In file included from Global.h:26:0,
                 from Sampler.cpp:3:
MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Global.h:26:0,
                 from xpath_modification.cpp:1:
MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Global.h:26:0,
                 from def.cpp:11:
MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Global.h:26:0,
                 from unit.h:10,
                 from unit.cpp:7:
MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        vtkLattice.cpp
  NVCC       cuda.cu
  G++        Solver.cpp
  G++        main.cpp
  G++        hdf5Lattice.cpp
In file included from Global.h:26:0,
                 from unit.h:10,
                 from Geometry.h:4,
                 from Geometry.cpp:18:
MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Global.h:26:0,
                 from vtkLattice.h:3,
                 from vtkLattice.cpp:12:
MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Global.h:26:0,
                 from Solver.cpp:11:
MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Global.h:26:0,
                 from main.cpp:11:
MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Global.h:26:0,
                 from hdf5Lattice.h:3,
                 from hdf5Lattice.cpp:12:
MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/vHandler.cpp
  LINKING    empty
  G++        Handlers/acRemoteForceInterface.cpp
  G++        Handlers/Action.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/vHandler.cpp:2:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acRemoteForceInterface.h:4,
                 from Handlers/acRemoteForceInterface.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/Callback.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/Action.h:4,
                 from Handlers/Action.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/conControl.cpp
  G++        Handlers/conControlParameter.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/Callback.h:4,
                 from Handlers/Callback.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/Design.cpp
  G++        Handlers/GenericAction.cpp
  G++        Handlers/GenericContainer.cpp
  G++        Handlers/GenericOptimizer.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/conControl.h:4,
                 from Handlers/conControl.cpp:9:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/conControlParameter.h:4,
                 from Handlers/conControlParameter.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/Design.h:4,
                 from Handlers/Design.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/GenericAction.h:4,
                 from Handlers/GenericAction.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/GenericContainer.h:4,
                 from Handlers/GenericContainer.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/acGeometry.cpp
  G++        Handlers/acInit.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/GenericOptimizer.h:4,
                 from Handlers/GenericOptimizer.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/acLoadBinary.cpp
  G++        Handlers/acLoadMemoryDump.cpp
  G++        Handlers/acObjective.cpp
  G++        Handlers/acOptimize.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acGeometry.h:4,
                 from Handlers/acGeometry.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acInit.h:4,
                 from Handlers/acInit.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/acOptSolve.cpp
  G++        Handlers/acParam.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acLoadBinary.h:4,
                 from Handlers/acLoadBinary.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acLoadMemoryDump.h:4,
                 from Handlers/acLoadMemoryDump.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acObjective.h:4,
                 from Handlers/acObjective.cpp:9:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acOptimize.h:4,
                 from Handlers/acOptimize.cpp:9:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/acRepeat.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acOptSolve.h:4,
                 from Handlers/acOptSolve.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/acSAdjoint.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acParam.h:4,
                 from Handlers/acParam.cpp:9:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/acSolve.cpp
  G++        Handlers/acSyntheticTurbulence.cpp
  G++        Handlers/acThreshold.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acRepeat.h:4,
                 from Handlers/acRepeat.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/acThresholdNow.cpp
  G++        Handlers/acUSAdjoint.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acSAdjoint.h:4,
                 from Handlers/acSAdjoint.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/cbAveraging.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acSolve.h:4,
                 from Handlers/acSolve.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/cbBIN.cpp
  G++        Handlers/cbCatalyst.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acSyntheticTurbulence.h:4,
                 from Handlers/acSyntheticTurbulence.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acThreshold.h:4,
                 from Handlers/acThreshold.cpp:9:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acThresholdNow.h:4,
                 from Handlers/acThresholdNow.cpp:9:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/acUSAdjoint.h:4,
                 from Handlers/acUSAdjoint.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/cbDumpSettings.cpp
  G++        Handlers/cbFailcheck.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbAveraging.h:4,
                 from Handlers/cbAveraging.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/cbHDF5.cpp
  G++        Handlers/cbKeep.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbBIN.h:4,
                 from Handlers/cbBIN.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbCatalyst.h:4,
                 from Handlers/cbCatalyst.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/cbLog.cpp
  G++        Handlers/cbPID.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbFailcheck.h:4,
                 from Handlers/cbFailcheck.cpp:9:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbDumpSettings.h:4,
                 from Handlers/cbDumpSettings.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/cbPythonCall.cpp
  G++        Handlers/cbRunR.cpp
  G++        Handlers/cbSample.cpp
  G++        Handlers/cbSaveBinary.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbHDF5.h:4,
                 from Handlers/cbHDF5.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbKeep.h:4,
                 from Handlers/cbKeep.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/cbSaveMemoryDump.cpp
Handlers/cbHDF5.cpp: In member function ‘virtual int cbHDF5::Init()’:
Handlers/cbHDF5.cpp:27:17: error: expected ‘;’ before ‘if’
                 if (write_xdmf) options = options | HDF5_WRITE_XDMF;
                 ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbLog.h:4,
                 from Handlers/cbLog.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
  G++        Handlers/cbStop.cpp
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbPID.h:4,
                 from Handlers/cbPID.cpp:9:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbPythonCall.h:4,
                 from Handlers/cbPythonCall.cpp:7:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
make[1]: *** [Handlers/cbHDF5.o] Error 1
make[1]: *** Waiting for unfinished jobs....
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbSaveBinary.h:4,
                 from Handlers/cbSaveBinary.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbSample.h:4,
                 from Handlers/cbSample.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbRunR.h:18,
                 from Handlers/cbRunR.cpp:8:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbSaveMemoryDump.h:4,
                 from Handlers/cbSaveMemoryDump.cpp:1:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
In file included from Handlers/../Global.h:26:0,
                 from Handlers/../CommonHandler.h:7,
                 from Handlers/cbStop.h:4,
                 from Handlers/cbStop.cpp:9:
Handlers/../MPMD.hpp: In member function ‘void MPMDHelper::Init(ompi_communicator_t* const&, const string&, std::vector<int>)’:
Handlers/../MPMD.hpp:161:10: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
          ^
Handlers/../MPMD.hpp:161:80: warning: ‘int MPI_Attr_get(MPI_Comm, int, void*, int*)’ is deprecated (declared at /net/software/local/openmpi/3.0.0-gnu-4.9.2-mxm-3.7/include/mpi.h:1241): MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0 [-Wdeprecated-declarations]
          MPI_Attr_get(MPI_COMM_WORLD, MPI_UNIVERSE_SIZE, &universe_sizep, &flag);  
                                                                                ^
make[1]: Leaving directory `/net/people/plgmuaddieb/GG_TCLB/CLB/d2q9'
make: *** [CLB/d2q9/main] Error 2
-------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
-------------------------------------------------------
--------------------------------------------------------------------------
mpirun detected that one or more processes exited with non-zero status, thus causing
the job to be terminated. The first process to do so was:

  Process name: [[44747,1],0]
  Exit code:    2
--------------------------------------------------------------------------
salloc: Relinquishing job allocation 17101469
```

the p/config.ini

```
$ cat p/conf.ini 
GRANT="clb2019"
TCLB="/net/people/plgmuaddieb/GG_TCLB"
RUN_GPU="y"
CONFOPT="--with-cuda-arch=sm_30 --enable-cpp11"
RHOME=""
DEBUGQ="plgrid-testing"
MAINQ="plgrid-gpu"
MAX_TASKS_PER_NODE="2"
MAX_TASKS_PER_NODE_FOR_COMPILATION="12"
CORES_PER_TASK_FULL="1"
MEMORY_PER_CORE="50"
MODULES_BASE="purge"
MODULES_ADD="plgrid/apps/r/3.4.4 plgrid/apps/cuda"
MODULES_RUN="plgrid/apps/r/3.4.4 plgrid/tools/openmpi/3.0.0-gcc-4.9.2 plgrid/apps/cuda/9.0"
PREPARE=""
PREPARE_CONFIGURE=""
PREPARE_MAKE=""
PREPARE_RUN=""
RUN_COMMAND="mpirun"
```

