### PR TITLE
Switching the coverage testing to codecov

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,2 @@
+ignore:
+  - "src/pugi*"  # ignore pugixml

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ jobs:
           - tools/deploy.docs.sh
 
 after_success:
-    - tools/coveralls.sh
+    - bash <(curl -s https://codecov.io/bash)
 
 after_failure:
     - dmesg

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ jobs:
           - tools/deploy.docs.sh
 
 after_success:
-    - bash <(curl -s https://codecov.io/bash)
+    - bash <(curl -s https://codecov.io/bash) -y .codecov.yaml
 
 after_failure:
     - dmesg

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 CudneLB - the templated version
 ===
-[![Build Status](https://travis-ci.org/CFD-GO/TCLB.svg?branch=develop)](https://travis-ci.org/CFD-GO/TCLB) [![Coverage Status](https://coveralls.io/repos/github/CFD-GO/TCLB/badge.svg?branch=develop)](https://coveralls.io/github/CFD-GO/TCLB?branch=develop)
+- [![Build Status](https://travis-ci.org/CFD-GO/TCLB.svg?branch=develop)](https://travis-ci.org/CFD-GO/TCLB) [![codecov](https://codecov.io/gh/CFD-GO/TCLB/branch/master/graph/badge.svg)](https://codecov.io/gh/CFD-GO/TCLB) - Stable release [(`master` branch)](https://github.com/CFD-GO/TCLB/tree/master)
+- [![Build Status](https://travis-ci.org/CFD-GO/TCLB.svg?branch=develop)](https://travis-ci.org/CFD-GO/TCLB) [![codecov](https://codecov.io/gh/CFD-GO/TCLB/branch/develop/graph/badge.svg)](https://codecov.io/gh/CFD-GO/TCLB) - Current release [(`develop` branch)](https://github.com/CFD-GO/TCLB/tree/develop)
 
 CudneLB is a MPI+CUDA or MPI+CPU high-performance CFD simulation code, based on Lattice Boltzmann Method.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CudneLB - the templated version
 ===
-- [![Build Status](https://travis-ci.org/CFD-GO/TCLB.svg?branch=develop)](https://travis-ci.org/CFD-GO/TCLB) [![codecov](https://codecov.io/gh/CFD-GO/TCLB/branch/master/graph/badge.svg)](https://codecov.io/gh/CFD-GO/TCLB) - Stable release [(`master` branch)](https://github.com/CFD-GO/TCLB/tree/master)
-- [![Build Status](https://travis-ci.org/CFD-GO/TCLB.svg?branch=develop)](https://travis-ci.org/CFD-GO/TCLB) [![codecov](https://codecov.io/gh/CFD-GO/TCLB/branch/develop/graph/badge.svg)](https://codecov.io/gh/CFD-GO/TCLB) - Current release [(`develop` branch)](https://github.com/CFD-GO/TCLB/tree/develop)
+- [![Build Status](https://travis-ci.org/CFD-GO/TCLB.svg?branch=develop)](https://travis-ci.org/CFD-GO/TCLB) [![codecov](https://codecov.io/gh/CFD-GO/TCLB/branch/master/graph/badge.svg)](https://codecov.io/gh/CFD-GO/TCLB) [![documentation](https://raw.githubusercontent.com/CFD-GO/documents/master/assets/documentation.svg?sanitize=true)](https://docs.tclb.io/) - Stable release [(`master` branch)](https://github.com/CFD-GO/TCLB/tree/master)
+- [![Build Status](https://travis-ci.org/CFD-GO/TCLB.svg?branch=develop)](https://travis-ci.org/CFD-GO/TCLB) [![codecov](https://codecov.io/gh/CFD-GO/TCLB/branch/develop/graph/badge.svg)](https://codecov.io/gh/CFD-GO/TCLB) [![documentation](https://raw.githubusercontent.com/CFD-GO/documents/master/assets/documentation.svg?sanitize=true)](https://develop.docs.tclb.io/) - Current release [(`develop` branch)](https://github.com/CFD-GO/TCLB/tree/develop)
 
 CudneLB is a MPI+CUDA or MPI+CPU high-performance CFD simulation code, based on Lattice Boltzmann Method.
 

--- a/src/conf.R
+++ b/src/conf.R
@@ -30,7 +30,7 @@ if (! SYMALGEBRA) {
 
 if (is.null(Options$autosym)) Options$autosym = FALSE
 
-source("linemark.R")
+#source("linemark.R")
 
 rows = function(x) {
 	rows_df= function(x) {

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -625,14 +625,8 @@ fi
 CP=cp
 if test "x${enable_marklines}" == "xyes"
 then
-	if test "x${enable_coverage}" == "xyes"
-	then
-		RTOPT="${RTOPT} --mark-lines --relative-to dummy -i linemark.R"
-		CP="./tools/cp_line HERE"
-	else	
-		RTOPT="${RTOPT} --mark-lines -i linemark.R"
-		CP=./tools/cp_line
-	fi
+	RTOPT="${RTOPT} --mark-lines -i linemark.R"
+	CP=./tools/cp_line
 fi
 
 if test "x${enable_paranoid}" == "xyes"

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -627,10 +627,10 @@ if test "x${enable_marklines}" == "xyes"
 then
 	if test "x${enable_coverage}" == "xyes"
 	then
-		RTOPT="${RTOPT} --mark-lines --relative-to dummy"
+		RTOPT="${RTOPT} --mark-lines --relative-to dummy -i linemark.R"
 		CP="./tools/cp_line HERE"
 	else	
-		RTOPT="${RTOPT} --mark-lines"
+		RTOPT="${RTOPT} --mark-lines -i linemark.R"
 		CP=./tools/cp_line
 	fi
 fi

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -625,8 +625,14 @@ fi
 CP=cp
 if test "x${enable_marklines}" == "xyes"
 then
-	RTOPT="${RTOPT} --mark-lines"
-	CP=./tools/cp_line
+	if test "x${enable_coverage}" == "xyes"
+	then
+		RTOPT="${RTOPT} --mark-lines --relative-to dummy"
+		CP="./tools/cp_line HERE"
+	else	
+		RTOPT="${RTOPT} --mark-lines"
+		CP=./tools/cp_line
+	fi
 fi
 
 if test "x${enable_paranoid}" == "xyes"

--- a/src/makefile.main.Rt
+++ b/src/makefile.main.Rt
@@ -73,13 +73,13 @@ $(MAKEHEADERS):tools/makeheaders.c
 wiki/Models.md : src/Models.md.Rt <?%s paste("wiki/", Models$model.md, sep="", collapse=" ") ?>
 	@echo "  RT         $@ (model)"
 	@$(MKPATH) $@
-	@$(RT) -q -f $< -I $(TOOLS),$(SRC) -w wiki/ -o $@ $(RTOPT) "MODELS=\"<?%s paste(Models$name,collapse=",")?>\"" || rm $@
+	@$(RT) -q -f $< -I $(TOOLS),$(SRC) -w wiki/ -o $@ "MODELS=\"<?%s paste(Models$name,collapse=",")?>\"" || rm $@
 	@$(INDENT) $@
 
 wiki/% : src/%.Rt
 	@echo "  RT         $@"
 	@$(MKPATH) $@
-	@$(RT) -q -f $< -I $(TOOLS),$(SRC) -w wiki/ -o $@ $(RTOPT) || rm $@
+	@$(RT) -q -f $< -I $(TOOLS),$(SRC) -w wiki/ -o $@ || rm $@
 	@$(INDENT) $@
 
 
@@ -135,9 +135,9 @@ for (d in destinations) {
 		src_all = paste(dest,src_all)
 		add = paste("$(addprefix ",dest,"/,$(ADDITIONALS))",sep="")
 		src_all = paste(src_all,add)
-		ropt = "$(RTOPT)"
-		if (adjoint) ropt = c(ropt, "$(RTOPT_ADJ)")
-		ropt = c(ropt, paste0("MODEL=\\\"",m,"\\\""))
+		rtopt = NULL
+		if (adjoint) rtopt = c(rtopt, "MODEL=TRUE")
+		rtopt = c(rtopt, paste0("MODEL=\\\"",m,"\\\""))
 		if (length(opts) > 0) {
 			opts = ifelse(opts==0,"FALSE","TRUE")
 			opts = paste0(names(opts),"=",opts,collapse=",")
@@ -145,7 +145,7 @@ for (d in destinations) {
 			opts = ""
 		}
 		opts = paste0("\"Options=list(",opts,")\"")
-		ropt = c(ropt,opts)
+		rtopt = c(rtopt,opts)
 		#paste0(names(opts),"=",a,collapse=",")
 ?>
 
@@ -189,7 +189,7 @@ for (d in destinations) {
 wiki/<?%s Models$model.md[i] ?>:$(SRC)/Model.md.Rt $(SRC)/conf.R <?%s model_path ?>/*
 	@echo "  RT         $@ (model)"
 	@$(MKPATH) $@
-	-@$(RT) -q -f $< -I $(TOOLS),$(SRC),<?%s model_path ?> -w wiki/ -o $@ <?%s ropt ?> || rm $@
+	-@$(RT) -q -f $< -I $(TOOLS),$(SRC),<?%s model_path ?> -w wiki/ -o $@ <?%s rtopt ?> || rm $@
 
 # for model <?%s m ?> and destination <?%s d ?>
 
@@ -208,19 +208,19 @@ wiki/<?%s Models$model.md[i] ?>:$(SRC)/Model.md.Rt $(SRC)/conf.R <?%s model_path
 <?%s d ?>/<?%s m ?>/makefile:$(SRC)/makefile.Rt <?%s model_path ?>/Dynamics.R $(SRC)/conf.R <?%s src_all ?>
 	@echo "  RT         $@"
 	@$(MKPATH) $@
-	@$(RT) -q -f $< -I $(TOOLS),$(SRC),<?%s model_path ?> -w <?%s d ?>/<?%s m ?>/ -o $@ <?%s ropt ?> || mv $@ $@~
+	@$(RT) -q -f $< -I $(TOOLS),$(SRC),<?%s model_path ?> -w <?%s d ?>/<?%s m ?>/ -o $@ <?%s rtopt ?> || mv $@ $@~
 
 
 <?%s d ?>/<?%s m ?>/%:$(SRC)/%.Rt <?%s model_path ?>/Dynamics.R $(SRC)/conf.R
 	@echo "  RT         $@"
 	@$(MKPATH) $@
-	@$(RT) -q -f $< -I $(TOOLS),$(SRC),<?%s model_path ?> -w <?%s d ?>/<?%s m ?>/ -o $@ <?%s ropt ?> || mv $@ $@~
+	@$(RT) -q -f $< -I $(TOOLS),$(SRC),<?%s model_path ?> -w <?%s d ?>/<?%s m ?>/ -o $@ $(RTOPT) <?%s rtopt ?> || mv $@ $@~
 	@$(INDENT) $@
 
 <?%s d ?>/<?%s m ?>/%.cpp:$(SRC)/%.cu.Rt <?%s model_path ?>/Dynamics.R $(SRC)/conf.R
 	@echo "  RT         $@"
 	@$(MKPATH) $@
-	@$(RT) -q -f $< -I $(TOOLS),$(SRC),<?%s model_path ?> -w <?%s d ?>/<?%s m ?>/ -o $@ <?%s ropt ?> || mv $@ $@~
+	@$(RT) -q -f $< -I $(TOOLS),$(SRC),<?%s model_path ?> -w <?%s d ?>/<?%s m ?>/ -o $@ $(RTOPT) <?%s rtopt ?> || mv $@ $@~
 	@$(INDENT) $@
 
 <?%s d ?>/<?%s m ?>/%.cpp:$(SRC)/%.cu <?%s model_path ?>/Dynamics.R $(SRC)/conf.R
@@ -231,13 +231,13 @@ wiki/<?%s Models$model.md[i] ?>:$(SRC)/Model.md.Rt $(SRC)/conf.R <?%s model_path
 <?%s d ?>/<?%s m ?>/%:<?%s model_path ?>/%.Rt <?%s model_path ?>/Dynamics.R $(SRC)/conf.R
 	@echo "  RT         $@ (model)"
 	@$(MKPATH) $@
-	@$(RT) -q -f $< -I $(TOOLS),$(SRC),<?%s model_path ?> -w <?%s d ?>/<?%s m ?>/ -o $@ <?%s ropt ?> || rm $@
+	@$(RT) -q -f $< -I $(TOOLS),$(SRC),<?%s model_path ?> -w <?%s d ?>/<?%s m ?>/ -o $@ $(RTOPT) <?%s rtopt ?> || rm $@
 	@$(INDENT) $@
 
 <?%s d ?>/<?%s m ?>/%.code:<?%s model_path ?>/%.Rt <?%s model_path ?>/Dynamics.R $(SRC)/conf.R
 	@echo "  RT         $@ (model)"
 	@$(MKPATH) $@
-	@$(RT) -q -c -f $< -I $(TOOLS),$(SRC),<?%s model_path ?> -w <?%s d ?>/<?%s m ?>/ -o $@ <?%s ropt ?> || rm $@
+	@$(RT) -q -c -f $< -I $(TOOLS),$(SRC),<?%s model_path ?> -w <?%s d ?>/<?%s m ?>/ -o $@ <?%s rtopt ?> || rm $@
 	@$(INDENT) $@
 
 <?%s d ?>/<?%s m ?>/%:<?%s model_path ?>/%
@@ -263,7 +263,7 @@ wiki/<?%s Models$model.md[i] ?>:$(SRC)/Model.md.Rt $(SRC)/conf.R <?%s model_path
 <?%s d ?>/%:$(SRC)/%.Rt
 	@echo "  RT         $@"
 	@$(MKPATH) $@
-	@$(RT) -q -f $< -I $(TOOLS) -w $(SRC)/ -o $@ $(RTOPT) || rm $@
+	@$(RT) -q -f $< -I $(TOOLS) -w $(SRC)/ -o $@ || rm $@
 	@$(INDENT) $@
 
 <?R } ?>

--- a/tools/cp_line
+++ b/tools/cp_line
@@ -1,14 +1,26 @@
 #!/bin/bash
 
+HERE=false
+if test "x$1" == "xHERE"
+then
+	HERE=true
+	shift
+fi
+
 if test "$#" -ne 2
 then
 	echo "usage: cp_line file1 file2"
-exit -1
+	exit -1
 fi
                 
 if test -f "$1"
 then
-	R --vanilla --slave -e "cat('#line 1 \"',rtemplate:::relativePath('$1','$2'),'\" \n',sep='')" >$2
+	if $HERE
+	then
+		R --vanilla --slave -e "cat('#line 1 \"',rtemplate:::relativePath('$1','dummy'),'\" \n',sep='')" >$2
+	else
+		R --vanilla --slave -e "cat('#line 1 \"',rtemplate:::relativePath('$1','$2'),'\" \n',sep='')" >$2
+	fi
 	cat $1 >> $2
 else
 	cp $1 $2


### PR DESCRIPTION
# Description
## Problem
For a long time the coverage analysis wasn't working (because of a string of non-compatibility and using legacy tools)
## Solution
Switching the code coverage analysis tool from [Coveralls](https://coveralls.io/) to [codecov](https://codecov.io/). The `codecov` interface is very clear and works out of the box with all weird things we use in the code.

## Notes
There were some changes to the code generation in the case of "mark-lines" option which should make it work more robustly.