### PR TITLE
Moving to a new formulation of tests

### DIFF
--- a/src/Handlers/cbPythonCall.cpp
+++ b/src/Handlers/cbPythonCall.cpp
@@ -38,6 +38,9 @@ int cbPythonCall::Init () {
 
             Py_Initialize();
             _import_array();
+            #else
+                ERROR("No Python support at compile time (./configure ... --enable-python)");
+                return -1;
             #endif
         }
 		return 0;
@@ -213,7 +216,8 @@ int cbPythonCall::DoIt () {
 //	    Py_Finalize();
 //END PYTHON HANDLING
 #else
-        output("Python support disabled at compile time, nothing to do");
+                ERROR("No Python support at compile time (./configure ... --enable-python)");
+                return -1;
 #endif
 
 

--- a/src/compare.cpp
+++ b/src/compare.cpp
@@ -104,6 +104,8 @@ struct Tab : public TabBase {
 	void read_piece(int pdx, int pdy, int pdz, int pnx, int pny, int pnz, pugi::xml_node node) {
 		assert(fname == node.attribute("Name").value());
 		assert(ftype == node.attribute("type").value());
+		assert(std::string("binary") == node.attribute("format").value());
+		assert(std::string("base64") == node.attribute("encoding").value());
 		size_t psize = 1L * (pnx - pdx) * (pny - pdy) * (pnz - pdz) * comp;
 		T *ptr;
 		b64.decode64(node.child_value(), (void **)&ptr, psize * sizeof(T));
@@ -243,7 +245,23 @@ int main(int argc, char *argv[]) {
 			exit(-1);
 		}
 		double diff = tabs1.tab[name]->compare(tabs2.tab[name].get());
-		printf("%s: Max difference: %lg\n", name.c_str(), diff);
+		printf("%s: Max difference: %lg", name.c_str(), diff);
+		double auto_eps;
+		if (tabs1.tab[name]->ftype == "Float64") {
+			auto_eps = 2.22e-16;
+		} else if (tabs1.tab[name]->ftype == "Float32") {
+			auto_eps = 1.19e-07;
+		} else {
+			auto_eps = 0;
+		}
+		if (auto_eps != 0) {
+			printf(" = %.1lf * %lg", diff / auto_eps, auto_eps);
+		}
+		if (diff > auto_eps * eps) {
+			printf(" --- WRONG\n");
+			exit(-1);
+		} else {
+			printf(" --- OK\n");
+		}		
 	}
-	
 }

--- a/src/compare.cpp
+++ b/src/compare.cpp
@@ -28,7 +28,7 @@ struct base64decoder {
 			rev64[((unsigned char *)base64char)[i]] = i;
 		rev64[(unsigned char)'='] = 0;
 	};
-	int dc64(const unsigned char *txt, unsigned char *optr, int n) {
+	void dc64(const unsigned char *txt, unsigned char *optr, int n) {
 		int v;
 		while (n > 0) {
 			v = rev64[txt[0]];
@@ -50,7 +50,7 @@ struct base64decoder {
 		}
 	}
 
-	int decode64(const char *txt, void **optr, int len) {
+	void decode64(const char *txt, void **optr, int len) {
 		int nlen;
 		unsigned char *ptr;
 		txt += 1;

--- a/src/compare.cpp
+++ b/src/compare.cpp
@@ -1,0 +1,249 @@
+#include "pugixml.hpp"
+#include <iostream>
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+#include <string>
+#include <map>
+#include <set>
+#include <memory>
+#include <math.h>
+
+std::string getPath (const std::string& str)
+{
+  size_t found;
+  found = str.find_last_of("/");
+  if (found != std::string::npos) return str.substr(0,found+1);
+  return "";
+}
+
+struct base64decoder {
+	const char *base64char = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	int rev64[256];
+	base64decoder() {
+		for (int i = 0; i < 256; i++)
+			rev64[i] = 666;
+		for (int i = 0; i < 64; i++)
+			rev64[((unsigned char *)base64char)[i]] = i;
+		rev64[(unsigned char)'='] = 0;
+	};
+	int dc64(const unsigned char *txt, unsigned char *optr, int n) {
+		int v;
+		while (n > 0) {
+			v = rev64[txt[0]];
+			v <<= 6;
+			v += rev64[txt[1]];
+			v <<= 6;
+			v += rev64[txt[2]];
+			v <<= 6;
+			v += rev64[txt[3]];
+
+			if (n > 2) optr[2] = v & 0xFF;
+			v >>= 8;
+			if (n > 1) optr[1] = v & 0xFF;
+			v >>= 8;
+			if (n > 0) optr[0] = v;
+			n -= 3;
+			optr += 3;
+			txt += 4;
+		}
+	}
+
+	int decode64(const char *txt, void **optr, int len) {
+		int nlen;
+		unsigned char *ptr;
+		txt += 1;
+		dc64((unsigned char *)txt, (unsigned char *)&nlen, 4);
+		txt += 8;
+		assert(len == nlen);
+		ptr = (unsigned char *)malloc(nlen);
+		dc64((unsigned char *)txt, ptr, nlen);
+		*optr = ptr;
+	}
+};
+
+struct TabBase {
+	static base64decoder b64;
+	int dx, dy, dz, nx, ny, nz, comp;
+	std::string fname;
+	std::string ftype;
+	size_t size;
+	size_t totsize;
+	TabBase(int dx_, int dy_, int dz_, int nx_, int ny_, int nz_, int comp_, std::string fname_, std::string ftype_) :
+		dx(dx_), dy(dy_), dz(dz_), nx(nx_), ny(ny_), nz(nz_), comp(comp_), fname(fname_), ftype(ftype_) {
+		size = 1L * (nx - dx) * (ny - dy) * (nz - dz);
+		totsize = size * comp;
+	}; 
+	virtual std::string getType() = 0;
+	virtual double compare(TabBase * other) = 0;
+	virtual void read_piece(int pdx, int pdy, int pdz, int pnx, int pny, int pnz, pugi::xml_node node) = 0;
+};
+
+base64decoder TabBase::b64;
+
+template <typename T>
+struct Tab : public TabBase {
+	std::vector<T> tab;
+	std::string getType() { return typeid(T).name(); }
+	double compare(TabBase * other_) {
+		double diff=0;
+		assert(ftype == other_->ftype);
+		Tab<T>* other = static_cast< Tab<T>* > (other_);
+		for (size_t i=0; i<totsize; i++) {
+			double vdiff = tab[i] - other->tab[i];
+			vdiff = fabs(vdiff);
+			if (vdiff > diff) diff = vdiff;
+		}	
+		return diff;
+	}
+	Tab(int dx_, int dy_, int dz_, int nx_, int ny_, int nz_, int comp_, std::string fname_, std::string ftype_) :
+		TabBase(dx_, dy_, dz_, nx_, ny_, nz_, comp_, fname_, ftype_) {
+		tab.resize(totsize);		
+	}
+	void read_piece(int pdx, int pdy, int pdz, int pnx, int pny, int pnz, pugi::xml_node node) {
+		assert(fname == node.attribute("Name").value());
+		assert(ftype == node.attribute("type").value());
+		size_t psize = 1L * (pnx - pdx) * (pny - pdy) * (pnz - pdz) * comp;
+		T *ptr;
+		b64.decode64(node.child_value(), (void **)&ptr, psize * sizeof(T));
+		int k, j, i, z;
+		T* tmp = ptr;
+		for (k = pdz; k < pnz; k++) {
+			for (j = pdy; j < pny; j++) {
+				for (i = pdx; i < pnx; i++) {
+					for (z = 0; z < comp; z++) {
+						T v = tmp[0];
+						size_t idx = z + comp*(i + nx * (j + ny * (k + 0L)));
+						tab[idx] = v;
+						tmp++;
+					}
+				}
+			}
+		}
+		free(ptr);		
+	}
+};
+
+struct Tabs {
+	std::string filename;
+	std::string path;
+	int dx, dy, dz, nx, ny, nz;
+	size_t size;
+	typedef std::shared_ptr<TabBase> TabBasePtr;
+	typedef std::map<std::string, TabBasePtr> TabMap;
+	TabMap tab;
+	
+	Tabs(std::string filename_) : filename(filename_) {
+		path = getPath(filename);
+		printf("Reading %s\n", filename.c_str());
+		pugi::xml_document file;
+		pugi::xml_node el;
+		file.load_file(filename.c_str());
+		el = file.child("VTKFile");
+		assert(el);
+		el = el.child("PImageData");
+		assert(el);
+		{
+			const char *reg;
+			reg = el.attribute("WholeExtent").value();
+			sscanf(reg, "%d %d %d %d %d %d", &dx, &nx, &dy, &ny, &dz, &nz);
+			size = 1L * (nx - dx) * (ny - dy) * (nz - dz);
+		}
+		printf("    Fields: ");
+		pugi::xml_node tcd = el.child("PCellData");
+		for (pugi::xml_node it = tcd.child("PDataArray"); it; it = it.next_sibling("PDataArray")) {
+			std::string ftype = it.attribute("type").value();
+			std::string fname = it.attribute("Name").value();
+			int fcomp = it.attribute("NumberOfComponents").as_int();
+			if (ftype == "Float64") {
+				tab[fname] = std::make_shared< Tab<double> >(dx,dy,dz,nx,ny,nz,fcomp,fname,ftype);
+			} else if (ftype == "Float32") {
+				tab[fname] = std::make_shared< Tab<float> >(dx,dy,dz,nx,ny,nz,fcomp,fname,ftype);
+			} else if (ftype == "UInt16") {
+				tab[fname] = std::make_shared< Tab<unsigned short int> >(dx,dy,dz,nx,ny,nz,fcomp,fname,ftype);
+			} else if (ftype == "UInt8") {
+				tab[fname] = std::make_shared< Tab<unsigned char> >(dx,dy,dz,nx,ny,nz,fcomp,fname,ftype);
+			} else {
+				printf("Unknown field type: %s\n", ftype.c_str());
+				exit(-1);
+			}
+			printf("%s, ", fname.c_str());
+		}
+		printf("\n");
+		for (pugi::xml_node it = el.child("Piece"); it; it = it.next_sibling("Piece"))
+		{
+			read_piece(it);
+		}
+	}
+
+	void read_piece(pugi::xml_node el) {
+		size_t psize = 0;
+		int pdx, pdy, pdz, pnx, pny, pnz;
+		{
+			const char *reg;
+			reg = el.attribute("Extent").value();
+			sscanf(reg, "%d %d %d %d %d %d", &pdx, &pnx, &pdy, &pny, &pdz, &pnz);
+			psize = (pnx - pdx) * (pny - pdy) * (pnz - pdz);
+		}
+		std::string filename = path + el.attribute("Source").value();
+		printf("    Piece: %s (%ld)\n", filename.c_str(), psize);
+		pugi::xml_document pfile;
+		pugi::xml_node pel;
+		pfile.load_file(filename.c_str());
+		pel = pfile.child("VTKFile");
+		assert(pel);
+		pel = pel.child("ImageData");
+		assert(pel);
+		pel = pel.child("Piece");
+		assert(pel);
+		pugi::xml_node tcd = pel.child("CellData");
+		assert(pel);
+		printf("        Fields: ");
+		for (pugi::xml_node it = tcd.child("DataArray"); it; it = it.next_sibling("DataArray")) {
+			std::string fname = it.attribute("Name").value();
+			if (tab.find(fname) != tab.end()) {
+				tab[fname]->read_piece(pdx, pdy, pdz, pnx, pny, pnz, it);
+			} else {
+				printf("No: %s\n", fname.c_str());
+			}
+			printf("%s, ", fname.c_str());
+		}
+		printf("\n");
+	}
+
+};
+
+int main(int argc, char *argv[]) {
+	double eps;
+	if (argc < 3) {
+		printf("usage: compare file1.pvti file2.pvti [epsilon]\n");
+		return -1;
+	} else if (argc < 4) {
+		eps = 1e-6;
+	} else {
+		sscanf(argv[3], "%lf", &eps);
+	}
+	printf("epsilon: %lg\n", eps);
+
+	Tabs tabs1(argv[1]);
+	Tabs tabs2(argv[2]);
+	
+	std::set< std::string > names;
+	for (Tabs::TabMap::iterator it = tabs1.tab.begin(); it != tabs1.tab.end(); it++) names.insert(it->first);
+	for (Tabs::TabMap::iterator it = tabs2.tab.begin(); it != tabs2.tab.end(); it++) names.insert(it->first);
+	for (std::set< std::string >::iterator it = names.begin(); it != names.end(); it++) {
+		std::string name = *it;
+		if (tabs1.tab.find(name) == tabs1.tab.end()) {
+			printf("%s not in first file\n", name.c_str());
+			exit(-1);
+		}
+		if (tabs2.tab.find(name) == tabs2.tab.end()) {
+			printf("%s not in second file\n", name.c_str());
+			exit(-1);
+		}
+		double diff = tabs1.tab[name]->compare(tabs2.tab[name].get());
+		printf("%s: Max difference: %lg\n", name.c_str(), diff);
+	}
+	
+}

--- a/src/makefile.Rt
+++ b/src/makefile.Rt
@@ -9,7 +9,7 @@ ARCH=sm_11                # CUDA architecture: sm_10 for capability 1.0, sm_13 f
 #CPU=1
 
 
-all:main empty
+all:main empty compare
 	@echo "  DONE       $^"
 
 include ../config.mk
@@ -67,6 +67,10 @@ main:main.o $(OBJ)
 endif
 
 empty:empty.o
+	@echo "  LINKING    $@"
+	@$(CXX) $^ -o $@ $(LD_OPT)
+
+compare : compare.o pugixml.o
 	@echo "  LINKING    $@"
 	@$(CXX) $^ -o $@ $(LD_OPT)
 

--- a/src/makefile.main.Rt
+++ b/src/makefile.main.Rt
@@ -31,6 +31,7 @@ SOURCE_PLAN+=xpath_modification.cpp xpath_modification.h
 SOURCE_PLAN+=hdf5Lattice.cpp hdf5Lattice.h
 SOURCE_PLAN+=glue.hpp
 SOURCE_PLAN+=mpitools.hpp
+SOURCE_PLAN+=compare.cpp
 
 <?R
 	h = dir("src/Handlers","[.](h|cpp)(|.Rt)$")

--- a/tools/tests.sh
+++ b/tools/tests.sh
@@ -150,20 +150,21 @@ function testModel {
 		t="$name.test"
 		TDIR="test-$MODEL-$name-$1"
 		test -d "$TDIR" && rm -r "$TDIR"
-		RESULT="FAILED"
+		RESULT="OK"
 		TCLB=".."
 		TEST_DIR="../tests/$MODEL"
 		if test -f "tests/$MODEL/$t"
 		then
 			echo "Running $name test..."
-			cat "tests/$MODEL/$t" | (
-				mkdir -p $TDIR
-				cd $TDIR
-				while read line
-				do
-					runline $(eval echo $line) || break
-				done
-			)
+			mkdir -p $TDIR		
+			while read line
+			do
+				if ! (cd $TDIR && runline $(eval echo $line))
+				then
+					RESULT="FAILED"
+					break
+				fi
+			done < "tests/$MODEL/$t"
 		else
 			echo "$t: test not found"
 			RESULT="NOT FOUND"
@@ -176,14 +177,11 @@ function testModel {
 	done
 }
 
-rm -r output-$MODEL-*/ 2>/dev/null || true
-
 REPEAT=1
 while test "$REPEAT" -le "$REPEATS"
 do
 	test "$REPEATS" -gt "1" && echo "############ repeat: $REPEAT ################"
 	testModel $REPEAT
-	mv -v output/ "output-$MODEL-$REPEAT"
 	REPEAT=$(expr $REPEAT + 1)
 done
 

--- a/tools/tests.sh
+++ b/tools/tests.sh
@@ -15,13 +15,16 @@ function usage {
 }
 
 function comment_wait {
-	echo -ne "[      ] $1\r"
+#       echo -ne "[      ] $1\r"
+        printf   "[      ] %-70s %4s\r" "$1" "$2"
 }
 function comment_ok {
-	echo -e "[\e[92m  OK  \e[0m] $1"
+#       echo -e "[\e[92m  OK  \e[0m] $1"
+        printf  "[\e[92m  OK  \e[0m] %-70s %6s\n" "$1" "$2"
 }
 function comment_fail {
-	echo -e "[\e[91m FAIL \e[0m] $1"
+#       echo -e "[\e[91m FAIL \e[0m] $1"
+        printf  "[\e[91m FAIL \e[0m] %-70s %6s\n" "$1" "$2"
 }
 
 function try {
@@ -44,7 +47,7 @@ function try {
 	fi
 	if test $NEG != $RES
 	then
-		comment_ok "$comment - $(cat $log.time)s"
+		comment_ok "$comment" "$(cat $log.time)s"
 		if $VERBOSE
 		then
 			(
@@ -54,7 +57,7 @@ function try {
 			) | sed 's|^|         |'
 		fi
 	else
-		comment_fail ""
+		comment_fail "$comment"
 		(
 			echo "----------------  CMD  ---------------"
 			echo $@
@@ -207,9 +210,9 @@ function testModel {
 #		echo -n "         Test \"$name\" returned:"
 		if test "x$RESULT" == "xOK"
 		then
-			comment_ok   "\"$name\" test"
+			comment_ok   "$name test finished" "-----"
 		else
-			comment_fail "\"$name\" test"
+			comment_fail "$name test finished" "-----"
 			GLOBAL="FAILED"
 		fi
 	done

--- a/tools/tests.sh
+++ b/tools/tests.sh
@@ -190,6 +190,7 @@ function testModel {
 		test -d "$TDIR" && rm -r "$TDIR"
 		RESULT="OK"
 		TCLB=".."
+		SOLVER="$TCLB/CLB/$MODEL/main"
 		TEST_DIR="../tests/$MODEL"
 		if test -f "tests/$MODEL/$t"
 		then


### PR DESCRIPTION
## Problem

The current tests rely on finding `*.xml` files and running them with a specific model. This is not extensible, and cannot cope with e.g. running solver in parallel or running test which should cause errors.

## Solution

The tests are now formulated in `*.test` files. There is a `*.test` file for every test, and each of them is executed in a separate, clean directory. Needed files are copied, the solver is executed according to the description in the `*.test` file, and results are compared. 

## Notes

The `*.test` files have form as follows:

```bash
need karman.xml
run $SOLVER karman.xml
csvdiff output/karman_Log_P00_00000000.csv
diff output/karman_VTK_P00_00001000.pvti
sha1 output/karman_VTK_P00_00001000.vti
```

The possible commands:

command | comment
--- | ---
`need ...` | copies files needed for a test
`run ...` | run solver
`fail ...` | run solver, but expect error
`diff file` | compare output `file` with `file` provided in test directory
`csvdiff file.csv` | compare `file.csv` up to a certain precision
`sha1 file` | compare `file` SHA1 sum with the sum provided in test directory
`pvtidiff file.pvti` | compare fields in VTK `pvti` file up to a certain precision


