### PR TITLE
Fixing issue with model options

### DIFF
--- a/src/makefile.main.Rt
+++ b/src/makefile.main.Rt
@@ -91,7 +91,7 @@ travis : .travis.yml
 	by(Models, Models$group, function(m) {
 		if (length(m$opts[[1]]) > 0) {
 			mat = do.call(rbind,m$opts)
-			mat = ifelse(mat==1, "X","-")
+			mat = ifelse(mat!=0, "X","-")
 			mat = as.data.frame(mat)
 			row.names(mat) = m$name
 		} else {

--- a/src/models.R
+++ b/src/models.R
@@ -44,11 +44,13 @@ get.models = function() {
 			opts = NULL
 		}
 		if (class(opts) == "formula") {
-			opts = terms(opts)
-			opts = attr(opts,"factors")
+			opts_terms = terms(opts)
+			opts = attr(opts_terms,"factors")
 			opts = data.frame(t(opts))
 			rownames(opts) = paste(name,gsub(":","_",rownames(opts)),sep="_")
-			opts[name,]=0
+			if (attr(opts_terms, "intercept") == 1) {
+				opts[name,]=0
+			}
 		} else {
 			opts = data.frame(row.names=name)
 		}
@@ -63,7 +65,7 @@ get.models = function() {
 			in.group=nrow(opts),
 			path=path
 		)
-		ret$opts = lapply(rownames(opts),function(n) as.list(opts[n,,drop=FALSE]))
+		ret$opts = lapply(rownames(opts),function(n) as.list(opts[n,,drop=FALSE]>0))
 		ret
 	}))
 #	Models=merge(Models, get.model.names(M3))

--- a/src/models.R
+++ b/src/models.R
@@ -51,6 +51,7 @@ get.models = function() {
 			if (attr(opts_terms, "intercept") == 1) {
 				opts[name,]=0
 			}
+#			opts = apply(opts, 2, function(x) x > 0)
 		} else {
 			opts = data.frame(row.names=name)
 		}
@@ -65,7 +66,7 @@ get.models = function() {
 			in.group=nrow(opts),
 			path=path
 		)
-		ret$opts = lapply(rownames(opts),function(n) as.list(opts[n,,drop=FALSE]>0))
+		ret$opts = lapply(rownames(opts),function(n) as.list(opts[n,,drop=FALSE]))
 		ret
 	}))
 #	Models=merge(Models, get.model.names(M3))


### PR DESCRIPTION
# Problem
## Description
There is no way now to make a model with options, which cannot be compiled without any option selected.
## Background
The option matrix generation is based on R *formula* syntax. In this syntax one can delete the *intercept* term in the formula by adding `-1` at the end of formula. But it was not supported by our compilation mechanism uptil now.

# Solution
I added the support for intercept term.

## Example
`OPT` | Models generated
--- | ---
`(A+B)*C` | `model`, `model_A`, `model_B`, `model_C`, `model_A_C`, `model_B_C`
`(A+B)*C-1` | `model_A`, `model_B`, `model_C`, `model_A_C`, `model_B_C`
`(A+B)*C-C-1` | `model_A`, `model_B`, `model_A_C`, `model_B_C`
