### PR TITLE
[hotfix] Change of dep.R call

### DIFF
--- a/src/makefile.main.Rt
+++ b/src/makefile.main.Rt
@@ -198,7 +198,7 @@ wiki/<?%s Models$model.md[i] ?>:$(SRC)/Model.md.Rt $(SRC)/conf.R <?%s model_path
 
 <?%s d ?>/<?%s m ?>/dep.mk:tools/dep.R <?%s src ?>
 	@echo "  AUTO-DEP   $@"
-	@cd <?%s d ?>/<?%s m ?>; $(RS) ../../$<
+	@$(RS) $< --args -d "<?%s d ?>/<?%s m ?>"
 
 <?%s d ?>/<?%s m ?>/makefile:$(SRC)/makefile.Rt <?%s model_path ?>/Dynamics.R $(SRC)/conf.R <?%s src_all ?>
 	@echo "  RT         $@"

--- a/tools/dep.R
+++ b/tools/dep.R
@@ -1,3 +1,13 @@
+#!/usr/bin/env Rscript
+
+library(optparse)
+options <- list(
+        make_option(c("-d","--path"), "store", default="", help="Work directory", type="character")
+)
+opt <- parse_args(OptionParser(usage="Usage: ADmod -f inputfile [-o outputfile]", options))
+
+if (opt$path != "") setwd(opt$path)
+
 # 'grep' all the includes
 f = pipe("grep '# *include' `find -regex '.*\\(c\\|cu\\|cpp\\|h\\|hpp\\)'` | sed -n 's/^\\([^:]*\\):[ \\t]*#[ \\t]*include[ \\t]*[\"<]\\(.*\\)[>\"]/\\1,\\2/gp'")
 w = read.csv(f,col.names=c("file","dep"), stringsAsFactor=F);


### PR DESCRIPTION
# Problem
## Description
If you use `R` from a Singularity container, it the compilation fail on the `dep.R` script.

## Details
A Singularity conrainer cannot access parent directories. This means that if `R` is run from a Singularity container, it cannot access any files in `../` path. As `dep.R` script was called from `CLB/[model[` directory, the execution fail.

# Solution
Changed the `dep.R` to get the `CLB/[model]` directory as argument.
