### PR TITLE
Fixed string type error in cbFailcheck::DoIt

### DIFF
--- a/src/Handlers/cbFailcheck.cpp
+++ b/src/Handlers/cbFailcheck.cpp
@@ -75,7 +75,7 @@ int cbFailcheck::DoIt () {
 			MPI_Allreduce(&cond,&fin,1,MPI_INT,MPI_LOR,MPMD.local);
 
                     if(fin ){
-			notice("Checking %s discovered NaN", it->name);
+			notice("Checking %s discovered NaN", it->name.c_str());
 			break;
 			}
 		}


### PR DESCRIPTION
One line bug fix to cast a CPP string (it->name) to a C string using .c_str() function.

Unstable branch now compiles and runs on Goliath cluster.