### PR TITLE
Correcting particle support for paranoid compilation

### DIFF
--- a/src/BallTree.h
+++ b/src/BallTree.h
@@ -41,7 +41,7 @@ public:
 //        printf("Building BallTree (%d) ...\n", n);
         nr.resize(n);
         if (n > 0) {
-            for (int i=0; i<n; ++i) nr[i] = i;
+            for (size_t i=0; i<n; ++i) nr[i] = i;
             build(0,n,-1);
         }
 //        printf("Done (%d)\n", tree.size());

--- a/src/Lattice.cu.Rt
+++ b/src/Lattice.cu.Rt
@@ -461,11 +461,11 @@ void Lattice::<?%s FunName ?>(int tab0, int tab1, int iter_type)
 		CudaMalloc(&container->particle_data, RFI.mem_size());
 	}
 	container->particle_data_size = RFI.size();
-//		for (int i=0; i<RFI.size(); i++){
+//		for (size_t i=0; i<RFI.size(); i++){
 //			printf("Particle: pos:%lg %lg %lg r:%lg\n",RFI.RawData(i, RFI_DATA_POS+0), RFI.RawData(i, RFI_DATA_POS+1), RFI.RawData(i, RFI_DATA_POS+2), RFI.RawData(i, RFI_DATA_R));
 //		}
 	if (true) {
-		for (int i=0; i<RFI.size(); i++){
+		for (size_t i=0; i<RFI.size(); i++){
 			RFI.RawData(i, RFI_DATA_FORCE+0) = 0;
 			RFI.RawData(i, RFI_DATA_FORCE+1) = 0;
 			RFI.RawData(i, RFI_DATA_FORCE+2) = 0;
@@ -526,7 +526,7 @@ void Lattice::<?%s FunName ?>(int tab0, int tab1, int iter_type)
         CudaStreamSynchronize(kernelStream);
 	DEBUG_PROF_PUSH("Testing particles for NaNs");
 	{	int nans = 0;
-		for (int i=0; i<RFI.size(); i++){
+		for (size_t i=0; i<RFI.size(); i++){
 			for (int j=0; j<3; j++){
 				if (! isfinite(RFI.RawData(i,RFI_DATA_FORCE+j))) {
 					nans++;


### PR DESCRIPTION
# Problem
TCLB with particle/DEM support was giving errors when compiled with `./configure --enable-paranoid`. Two types of error are found:
- [x] signed/unsigned int mismatch in couple of loops
- [x] possible non-initialized values, when there are no particles

# Solution
Changed the index to `size_t` in the loops, and initialized particle structure with zeros when there are no particles in the RFI.
