### PR TITLE
Fixing bug in atomicSumWarpArr

### DIFF
--- a/src/cross.hpp
+++ b/src/cross.hpp
@@ -113,11 +113,11 @@ __device__ inline void atomicSumWarp(real_t * sum, real_t val)
 __device__ inline void atomicSumWarpArr(real_t * sum, real_t * val, unsigned char len)
 {
 	#define FULL_MASK 0xffffffff
-	bool pred = true;
-	for (unsigned char i=0; i<len; i++) pred = val[i] != 0.0;
+	bool pred = false;
+	for (unsigned char i=0; i<len; i++) pred = pred || (val[i] != 0.0);
 	if (__any_sync(FULL_MASK, pred)) {
 		for (int offset = 16; offset > 0; offset /= 2) {
-			for (unsigned char i=0; i<len; i++) val[i] += __shfl_down_sync(FULL_MASK, val[i], offset);
+			for (unsigned char i=0; i<len; i++) val[i] += __shfl_xor_sync(FULL_MASK, val[i], offset);
 		}
 		if (threadIdx.x < len) {
 			atomicAddP(sum+threadIdx.x,val[threadIdx.x]);
@@ -140,11 +140,11 @@ __device__ inline void atomicSumWarp(real_t * sum, real_t val)
 __device__ inline void atomicSumWarpArr(real_t * sum, real_t * val, unsigned char len)
 {
 	#define FULL_MASK 0xffffffff
-	bool pred = true;
-	for (unsigned char i=0; i<len; i++) pred = val[i] != 0.0;
+	bool pred = false;
+	for (unsigned char i=0; i<len; i++) pred = pred || (val[i] != 0.0);
 	if (__any(pred)) {
 		for (int offset = 16; offset > 0; offset /= 2) {
-			for (unsigned char i=0; i<len; i++) val[i] += __shfl_down(val[i], offset);
+			for (unsigned char i=0; i<len; i++) val[i] += __shfl_xor(val[i], offset);
 		}
 		if (threadIdx.x < len) {
 			atomicAddP(sum+threadIdx.x,val[threadIdx.x]);


### PR DESCRIPTION
# Problem
## Description
The force totals on particles were wrong because of an error in reduction procedures. The error was in most cases small and only occurred in specific situations (and only on gpu).

## Details
`atomicSumWarpArr` function was using `__shfl_down` which calculated the sum only on the 0th thread. But the sum was used on all threads with `threadIdx.x < len`. This caused wrong results in some cases.

# Solution
I changed the implementation of `atomicSumWarpArr` to use `__shfl_xor` (some details about the functions can be found [on nvidia](https://devblogs.nvidia.com/faster-parallel-reductions-kepler/))