### PR TITLE
Feature/stl

### DIFF
--- a/src/Geometry.cpp.Rt
+++ b/src/Geometry.cpp.Rt
@@ -384,25 +384,41 @@ inline int inWedge(double x, double y, double z, const char *type)
 /// Transform STL points according to attributes of an XML element
 inline int Geometry::transformSTL(int ntri, STL_tri * tri, pugi::xml_node n)
 {
-    if (n.attribute("Xrot")) {
-	double v = units.alt(n.attribute("Xrot").value());
-	debug1("STL: rotating X axis %lf (%lf deg)\n", v, v / 4. / atan(1.) * 180);
-	double y, z;
-	for (int i = 0; i < ntri; i++) {
-	    y = tri[i].p1[1];
-	    z = tri[i].p1[2];
-	    tri[i].p1[1] = cos(v) * y - sin(v) * z;
-	    tri[i].p1[2] = sin(v) * y + cos(v) * z;
-	    y = tri[i].p2[1];
-	    z = tri[i].p2[2];
-	    tri[i].p2[1] = cos(v) * y - sin(v) * z;
-	    tri[i].p2[2] = sin(v) * y + cos(v) * z;
-	    y = tri[i].p3[1];
-	    z = tri[i].p3[2];
-	    tri[i].p3[1] = cos(v) * y - sin(v) * z;
-	    tri[i].p3[2] = sin(v) * y + cos(v) * z;
+	for (int d = 0; d < 3; d++) {
+		std::string d_char;
+		int id1 = 0;
+		int id2 = 0;
+		if (d == 0) {
+			d_char = "X"; id1 = 1; id2 = 2;
+		} else if (d == 1) {
+			d_char = "Y"; id1 = 2; id2 = 0;
+		} else if (d == 2) {
+			d_char = "Z"; id1 = 0; id2 = 1;
+		} else {
+			ERROR("This cannot happen."); return -1;
+		}
+		std::string attr_name = d_char + "rot";
+		pugi::xml_attribute attr = n.attribute(attr_name.c_str());
+		if (attr) {
+			double v = units.alt(attr.value());
+			debug1("STL: rotating %s axis %lf (%lf deg)\n", d_char.c_str(), v, v / 4. / atan(1.) * 180);
+			double y, z;
+			for (int i = 0; i < ntri; i++) {
+			    y = tri[i].p1[id1];
+			    z = tri[i].p1[id2];
+			    tri[i].p1[id1] = cos(v) * y - sin(v) * z;
+			    tri[i].p1[id2] = sin(v) * y + cos(v) * z;
+			    y = tri[i].p2[id1];
+			    z = tri[i].p2[id2];
+			    tri[i].p2[id1] = cos(v) * y - sin(v) * z;
+			    tri[i].p2[id2] = sin(v) * y + cos(v) * z;
+			    y = tri[i].p3[id1];
+			    z = tri[i].p3[id2];
+			    tri[i].p3[id1] = cos(v) * y - sin(v) * z;
+			    tri[i].p3[id2] = sin(v) * y + cos(v) * z;
+			}
+		}
 	}
-    }
     if (n.attribute("scale")) {
 	double v = units.alt(n.attribute("scale").value());
 	debug1("STL: scaling %lf\n", v);


### PR DESCRIPTION
# Problem
The `<STL/>` element only supports rotation in the X axis (with `Xrot=` attribute).

# Solution
Added support for X, Y and Z rotations.