### PR TITLE
+ alter line so that Gadi will compile with hdf5

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -366,7 +366,7 @@ if test "x${with_hdf5}" != "xno"; then
 	fi
 	has_hdf5="yes"
 	AC_CHECK_HEADERS([hdf5.h],[],[has_hdf5="no"])
-	AC_CHECK_LIB([${hdf5_lib_name}], [H5Pset_fapl_mpio],[],[has_hdf5="no"])
+	AC_CHECK_LIB([hdf5], [H5Pset_fapl_mpio],[],[has_hdf5="no"])
 	if test "x${has_hdf5}" == "xyes"; then
 		AC_DEFINE([WITH_HDF5], [1], [Using HDF5])
 	else


### PR DESCRIPTION
Fresh pull of TCLB develop on gadi doesn't currently compile with hdf5. Adjusted line to what I had in my configure.ac that did compile and use hdf5 and is similar to the command for mpi.