### PR TITLE
Adding keepcode option to configure

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -120,6 +120,9 @@ AC_ARG_ENABLE([paranoid],
 AC_ARG_ENABLE([profiling],
 	AC_HELP_STRING([--enable-profiling],
 		[enable profiling for R in rtemplate]))		
+AC_ARG_ENABLE([keepcode],
+	AC_HELP_STRING([--enable-keepcode],
+		[keeps the R code for rtemplate along with the generated file]))
 
 AC_ARG_WITH([cpp-flags],
 	AC_HELP_STRING([--with-cpp-flags=FLAGS],
@@ -714,6 +717,11 @@ fi
 if test "x${enable_profiling}" == "xyes"
 then
 	RTOPT="${RTOPT} -p"
+fi
+
+if test "x${enable_keepcode}" == "xyes"
+then
+	RTOPT="${RTOPT} --keep-code"
 fi
 
 # Checks for typedefs, structures, and compiler characteristics.


### PR DESCRIPTION
# Problem
As pointed in #292 it would be useful to keep the R code which the RTemplate translates to for debugging.

# Solution
A new option was introduced to `RT` (llaniewski/rtemplate#1) which stores the R code alongside the generated file. This can be activated through `./configure` script with:
```bash
./configure --enable-keepcode
make d2q9
cat CLB/d2q9/Handlers/acObjective.cpp # The generated file
cat CLB/d2q9/Handlers/acObjective.cpp.code.R # The intermediate R code
```

Additionally if `RT` generation fails, it will now always generate the intermediate R code for inspection.

## Notes
Closes #292
This can be of interest to @mdzik @TravisMitchell 
