### PR TITLE
Moving all tests to "by value" approach

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "TCLB_tests"]
 	path = tests
-	url =  https://github.com/CFD-GO/TCLB_tests.git
+	url =  ../../CFD-GO/TCLB_tests.git

--- a/src/compare.cpp
+++ b/src/compare.cpp
@@ -234,34 +234,40 @@ int main(int argc, char *argv[]) {
 	std::set< std::string > names;
 	for (Tabs::TabMap::iterator it = tabs1.tab.begin(); it != tabs1.tab.end(); it++) names.insert(it->first);
 	for (Tabs::TabMap::iterator it = tabs2.tab.begin(); it != tabs2.tab.end(); it++) names.insert(it->first);
+	bool result = true;
 	for (std::set< std::string >::iterator it = names.begin(); it != names.end(); it++) {
 		std::string name = *it;
 		if (tabs1.tab.find(name) == tabs1.tab.end()) {
 			printf("%s not in first file\n", name.c_str());
-			exit(-1);
-		}
-		if (tabs2.tab.find(name) == tabs2.tab.end()) {
+			result = false;
+		} else if (tabs2.tab.find(name) == tabs2.tab.end()) {
 			printf("%s not in second file\n", name.c_str());
-			exit(-1);
-		}
-		double diff = tabs1.tab[name]->compare(tabs2.tab[name]);
-		printf("%s: Max difference: %lg", name.c_str(), diff);
-		double auto_eps;
-		if (tabs1.tab[name]->ftype == "Float64") {
-			auto_eps = 2.22e-16;
-		} else if (tabs1.tab[name]->ftype == "Float32") {
-			auto_eps = 1.19e-07;
+			result = false;
 		} else {
-			auto_eps = 0;
+			double diff = tabs1.tab[name]->compare(tabs2.tab[name]);
+			printf("%s: Max difference: %lg", name.c_str(), diff);
+			double auto_eps;
+			if (tabs1.tab[name]->ftype == "Float64") {
+				auto_eps = 2.22e-16;
+			} else if (tabs1.tab[name]->ftype == "Float32") {
+				auto_eps = 1.19e-07;
+			} else {
+				auto_eps = 0;
+			}
+			if (auto_eps != 0) {
+				printf(" = %.1lf * %lg", diff / auto_eps, auto_eps);
+			}
+			if (diff > auto_eps * eps) {
+				printf(" --- WRONG\n");
+				result = false;
+			} else {
+				printf(" --- OK\n");
+			}		
 		}
-		if (auto_eps != 0) {
-			printf(" = %.1lf * %lg", diff / auto_eps, auto_eps);
-		}
-		if (diff > auto_eps * eps) {
-			printf(" --- WRONG\n");
-			exit(-1);
-		} else {
-			printf(" --- OK\n");
-		}		
+	}
+	if (result) {
+		return 0;
+	} else {
+		return -1;
 	}
 }

--- a/tools/tests.sh
+++ b/tools/tests.sh
@@ -139,9 +139,9 @@ fi
 
 if test -z "$TESTS"
 then
-	echo "No tests for model $MODEL \(WARNING: there is a directory tests/$MODEL !\)"
-	echo "Exiting with error. Because I Can."
-	exit -1
+	echo "No tests for model $MODEL (WARNING: there is a directory tests/$MODEL)"
+	echo "Exiting with no error."
+	exit 0
 fi
 
 
@@ -150,9 +150,9 @@ export PYTHONPATH="$PYTHONPATH:$PWD/tools/python"
 
 function runline {
 	CMD=$1
-	R=$2
-	G=$TEST_DIR/$R
 	shift
+	R=$1
+	G=$TEST_DIR/$R
 	case $CMD in
 	need) 
 		comment_wait "copy $@"
@@ -175,7 +175,7 @@ function runline {
 	csvdiff) try "checking $R (csvdiff)" $TCLB/tools/csvdiff -a "$R" -b "$G" -x 1e-10 -d Walltime ;;
 	diff) try "checking $R" diff "$R" "$G" ;;
 	sha1) try "checking $R (sha1)" sha1sum -c "$G.sha1" ;;
-	pvtidiff) try "checking $R (pvtidiff)" $TCLB/CLB/$MODEL/compare "$R" "$G" 8;;
+	pvtidiff) try "checking $R (pvtidiff)" $TCLB/CLB/$MODEL/compare "$R" "$G" "${2:-8}" ;; # ${2:-8} is { if $2 == "" then "8" else $2 }
 	*) echo "unknown: $CMD"; return -1;;
 	esac
 	return 0;


### PR DESCRIPTION
# Problem
In #213 I postulated that comparing results based on SHA1 sums is not a good long term strategy.

The current system makes:
- testing on different architectures impossible
- contributing new test hard

# Solution
#259 introduced comparison of vti files based **on value** not checksum. This pull request removes the checksum tests entirely.

## Details
I removed the checksums for vti files, and kept just the last vti file for every test. 

## Heavy tests
This makes `TCLB_tests` repository potentially heavy in the future. We'll try to deal with it as it comes.

### Potential for GIT LFS
The `git lfs` adds a useful interface for tracking heavy files in git. The problem is that github imposes 1GB storage and 1GB/month bandwidth cap. The bandwidth especially would run out quickly combined with our continuous integration (tests on Travis-CI).

