### PR TITLE
Correcting d3q27_kl for unitialized value

### DIFF
--- a/models/nonnewtonian/d3q27_kl/Dynamics.c.Rt
+++ b/models/nonnewtonian/d3q27_kl/Dynamics.c.Rt
@@ -229,17 +229,17 @@ CudaDeviceFunction void PressureHB_Xn() {
 
     if (TimeMod < t1) {
         Pin = 0;
-    } else if (TimeMod >= t1 && TimeMod < t2) {
+    } else if (TimeMod < t2) {
         Pin = Pmax*m1*(TimeMod-t1)/(t2-t1);
-    } else if (TimeMod >= t2 && TimeMod < t3) {
+    } else if (TimeMod < t3) {
         Pin = -Pmax*m1*(TimeMod-t3)/(t3-t2);
-    } else if (TimeMod >= t3 && TimeMod < t4) {
+    } else if (TimeMod < t4) {
         Pin = Pmax*m2*(TimeMod-t3)/(t4-t3);
-    } else if (TimeMod >= t4 && TimeMod < t6) {
+    } else if (TimeMod < t6) {
         Pin = (Pmax-m2*Pmax)/((t5-t4)*(t5-t6))*(TimeMod-t4)*(TimeMod-t6)+m2*Pmax;
-    } else if (TimeMod >= t6 && TimeMod <= Period) {
+    } else if (TimeMod <= Period) {
         Pin = -Pmax*m2*(TimeMod-Period)/(Period-t6);
-    }
+    } else Pin = 0;
 
     rho =  Density + 3.0*Pin;
 


### PR DESCRIPTION
Of course just after I merged, I noticed an small bug in the d3q27_kl.
@bhill23, to make sure `Pin` is always initialized, I added a final `else` statement in the code. In cases of initializing values, it's generally a good idea to make such a `else` clause even if you are certain one of the conditions would be triggered. This is because uninitialized-value bugs are very hard to notice, find and debug. In many cases they will present themselves only on specific architectures.

@bhill23, could you test if everything works from your side after this change?
```bash
git clone https://github.com/llaniewski/TCLB.git TCLB_patch
cd TCLB_patch
git checkout patch/llaniewski-d3q27_kl
make configure
./configure [your options]
make -j 16 d3q27_kl
[make tests involving this part of code]
```
If everything is good, approve changes in this pull request.