### PR TITLE
Fixing bug in Handler reference counting

### DIFF
--- a/src/Handlers.h
+++ b/src/Handlers.h
@@ -16,6 +16,8 @@ public:
 	int *ref; ///< Number of references of the shared pointer
 /// Constructs a Handler based on a XML element
 	inline Handler(pugi::xml_node node, Solver * solver_) {
+		ref = new int;
+		*ref=1;
 		hand = HandlerFactory::Produce(node);
 		if (hand == NULL) {
 			ERROR("Unknown Handler: %s",node.name());
@@ -28,16 +30,30 @@ public:
 			delete hand;
 			hand = NULL;
 		}
-		ref = new int;
-		*ref=1;
-		debug0("Handler shared pointer: create\n");
 	}
 /// Makes another reference of the shared pointer
-	inline Handler(const Handler & that) {
+	inline void Handler_inc(const Handler & that) {
 		hand = that.hand;
 		ref = that.ref;
 		(*ref)++;
-		debug0("Handler shared pointer++: %d\n", *ref);
+	}
+	inline void Handler_dec() {
+		(*ref)--;
+		if ((*ref) < 0) {
+			ERROR("Handler ptr ref below zero (%p).", hand);
+			exit(-1);
+		} else if ((*ref) == 0) {
+			if (hand) {
+				hand->Finish();
+				delete hand;
+			}
+			delete ref;
+		}
+		hand = NULL;
+		ref = NULL;
+	}
+	inline Handler(const Handler & that) {
+		Handler_inc(that);
 	}
 /// Dispatches Init on the vHandler
 	inline const int Init() { return hand->Init(); }
@@ -53,10 +69,8 @@ public:
 	inline const int Prev(int iter) { return hand->Prev(iter); }
 /// Makes another reference of the shared pointer
 	inline Handler & operator=(const Handler & that) {
-		hand = that.hand;
-		ref = that.ref;
-		(*ref)++;
-		debug0("Handler shared pointer++: %d\n", *ref);
+		Handler_dec();
+		Handler_inc(that);
 		return *this;
 	}
 /// Gets the vHandler
@@ -64,15 +78,7 @@ public:
 	vHandler* operator-> () { return hand; }
 /// Deletes a shared pointer reference
 	inline ~Handler() {
-		(*ref)--;
-		debug0("Handler shared pointer--: %d\n", *ref);
-		if (*ref <= 0) {
-			if (hand) {
-				hand->Finish();
-				delete hand;
-			}
-			delete ref;
-		}
+		Handler_dec();
 	}
 /// Checks in the handler is non-null
 	inline operator bool () { return hand != NULL; }

--- a/src/Handlers.h
+++ b/src/Handlers.h
@@ -66,7 +66,7 @@ public:
 	inline ~Handler() {
 		(*ref)--;
 		debug0("Handler shared pointer--: %d\n", *ref);
-		if (ref <= 0) {
+		if (*ref <= 0) {
 			if (hand) {
 				hand->Finish();
 				delete hand;

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -146,7 +146,7 @@ AC_PROG_CXX
 AC_PROG_CC
 
 # Checks for header files.
-AC_CHECK_HEADERS([float.h malloc.h stddef.h stdint.h stdlib.h string.h wchar.h],[],[AC_MSG_ERROR([Cannot find standart headers])])
+AC_CHECK_HEADERS([float.h stddef.h stdint.h stdlib.h string.h wchar.h],[],[AC_MSG_ERROR([Cannot find standart headers])])
 AC_CHECK_LIB([m], [sqrt],[],[AC_MSG_ERROR([Didn't find math Library])])
 
 if test "x${enable_double}" != "xno"

--- a/src/cross.h
+++ b/src/cross.h
@@ -108,7 +108,6 @@
   #else
     #include <assert.h>
     #include <time.h>
-    #include <malloc.h>
     #include <cstdlib>
     #include <cstring>
     #include <math.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -402,10 +402,12 @@ int main ( int argc, char * argv[] )
 	solver->lattice->Callback((int(*)(int, int, void*)) MainCallback, (void*) solver);
 
 	// Running main handler (it makes all the magic)
-	Handler hand(config, solver);
-	if (!hand) {
-		error("Something went wrong in xml run!\n");
-		return -1;
+	{
+		Handler hand(config, solver);
+		if (!hand) {
+			error("Something went wrong in xml run!\n");
+			return -1;
+		}
 	}
     #ifdef EMBEDED_PYTHON
     Py_Finalize();


### PR DESCRIPTION
This PR fixes a bug which persisted in the code apparently for a long time in checking reference count of Handlers. This will cause Handlers to be `Finish`-ed properly and deleted. Other unwanted behaviour can be caused by this change, as until now Handlers weren't deleted until the end of the simulation.