### PR TITLE
+ d3q27_pf_velocity contact angle fixes

### DIFF
--- a/models/multiphase/d3q27_pf_velocity/Dynamics.R
+++ b/models/multiphase/d3q27_pf_velocity/Dynamics.R
@@ -161,7 +161,7 @@ if (Options$thermo){
 }
 
 # Stages - processes to run for initialisation and each iteration
-AddStage("WallInit"  , "Init_wallNorm", save=Fields$group=="nw")
+AddStage("WallInit"  , "Init_wallNorm", save=Fields$group %in% c("nw"))
 AddStage("calcWall"  , "calcWallPhase", save=Fields$name=="PhaseF", load=DensityAll$group=="nw")
 
 if (Options$OutFlow){
@@ -180,7 +180,7 @@ if (Options$OutFlow){
 	                                	         load=DensityAll$group %in% c("g","h","Vel","nw","Thermal","PF"))
 } else {
 	AddStage("PhaseInit" , "Init", save=Fields$name=="PhaseF")
-    AddStage("BaseInit"  , "Init_distributions", save=Fields$group %in% c("g","h","Vel","PF"))
+    AddStage("BaseInit"  , "Init_distributions", save=Fields$group %in% c("g","h","Vel"))
     AddStage("calcPhase" , "calcPhaseF",	 save=Fields$name=="PhaseF", 
 					         load=DensityAll$group %in% c("g","h","Vel","nw") )
     AddStage("BaseIter"  , "Run"       ,         save=Fields$group %in% c("g","h","Vel","nw"), 

--- a/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
+++ b/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
@@ -35,6 +35,8 @@
 //				  surrounded by all solid nodes
 //				- Check added for these cases to stop nan appearances
 //		28/04/2020: Added thermocapillary effects option
+//		24/09/2020: Fixed how solidFlag is created in initialisation to not rely on int division for a true/false reading
+//			    Hack placed in to avoid edge case where normal solid direction points to another solid cell, need a more elegant fix.
 
 <?R
     g=PV(DensityAll$name[DensityAll$group=="g"])
@@ -117,6 +119,8 @@ U_inv = PV("invU")
 
 #include <math.h>
 #define PI 3.14159265
+#define ABS(X)  ((X>=0)? X : -(X) )
+#define ROUND(X)  (X>=0)? (int) (X + 0.5) : (int)-(ABS(X)+0.5)
 
 /* MRT Matrix Check:
 <?R
@@ -643,17 +647,25 @@ CudaDeviceFunction void calcWallPhase(){
 	PhaseF = PhaseF(0,0,0); //For fluid nodes.
 	if ( IamWall || IamSolid ) {
 		real_t a, h, pf_f;
+		// So we don't rely on implicit double to int conversion.
+		// Here we explicitly create normal indices.
+		int ind_nw_x = ROUND(nw_x);
+		int ind_nw_y = ROUND(nw_y);
+		int ind_nw_z = ROUND(nw_z);
 
-		pf_f = PhaseF_dyn(nw_x, nw_y, nw_z);
+		pf_f = PhaseF_dyn(ind_nw_x, ind_nw_y, ind_nw_z);
 		h = 0.5 * sqrt(nw_x*nw_x + nw_y*nw_y + nw_z*nw_z);
 		
 		if (h < 0.001) { 
-		// If I am a wall/solid node and I am surrounded by solid nodes
+		// This occurs if I am a wall/solid node and I am surrounded by solid nodes
+		// or I am an edge case in which my normal direction points towards a solid node.
 			PhaseF = 1;
 		} else if (ContactAngle == 90){
-		// If I am not surrounded, but contact angle is 90
+		// If I am not surrounded, but contact angle is 90 then my value is equal to the 
+		// fluid cell in the normal direction.
 			PhaseF = pf_f;
 		} else {
+		// This is for all the solid nodes with normal directions pointing towards a fluid node.
 			a = -h * (4.0/IntWidth) * cos(radAngle);
 			PhaseF = (1 + a - sqrt( (1+a)*(1+a) - 4*a*pf_f))/(a+1e-12) - pf_f;
 		}
@@ -804,31 +816,28 @@ CudaDeviceFunction void Init() {
 CudaDeviceFunction void Init_wallNorm(){
 	PhaseF = PhaseF(0,0,0);
 
-	if ( IamWall || IamSolid ) {
-	// Am I surrounded by solid nodes?
+	if ( IamWall || IamSolid || PhaseF < -998 ) {
+		// Test if I am surrounded by solid nodes:
 		int i,j,k;
 	  	real_t tmp = 0.0;
 	  	for (i=-1;i<2;i++){for (j=-1;j<2;j++){for (k=-1;k<2;k++){
 			tmp += PhaseF_dyn(i,j,k);
 	  	}}}
 
-	  	if ( abs(tmp) > 26000){
-		// yes I am surrounded (sum(pf) = 27*-999 = -26973 if surrounded):
+	  	if ( abs(tmp) > 26900){
+			// yes I am surrounded (sum(pf) = 27*-999 = -26973):
 			nw_x = 0.0;nw_y = 0.0;nw_z = 0.0;
 	  	} else { 
 		// no I am not surrounded, so calc normal:
-			int solidFlag[27], maxi;
+			int solidFlag[27] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+			int maxi=0;
 			real_t myNorm[3] = {0.0,0.0,0.0};
-			real_t maxn=0.0, dot;
+			real_t maxn = 0.0;
+			real_t dot  = 0.0;
 
 			// Calculate the normal direction:
-			<?R
-			    myN   = PV(paste0("myNorm[",1:3-1,"]"))
-			    pf    = PV(paste0("PhaseF(",U[,1],",",U[,2],",",U[,3],")/-998"))
-			    solid = PV(paste0("solidFlag[",1:27-1,"]"))
-			
-			    C(solid, pf)
-			?>
+			<?R for (i in 1:27){	?> 
+			if (PhaseF(<?R C(U[i,1])?>, <?R C(U[i,2])?>, <?R C(U[i,3])?>) < -998) solidFlag[<?R C(i-1) ?>] = 1; <?R }	?>
 			for (i=0;i<27;i++){
 				myNorm[0] += wg[i] * solidFlag[i] * d3q27_ex[i];
 				myNorm[1] += wg[i] * solidFlag[i] * d3q27_ey[i];
@@ -847,13 +856,15 @@ CudaDeviceFunction void Init_wallNorm(){
 					maxn = dot; maxi = i;
 				}
 			}
-			if (maxi < 0) {
-				// This should not happen ?
-				nw_x = 0.0;nw_y = 0.0;nw_z = 0.0;
-			} else {
-				nw_x = d3q27_ex[maxi];nw_y = d3q27_ey[maxi];nw_z = d3q27_ez[maxi];
+			nw_x = d3q27_ex[maxi];nw_y = d3q27_ey[maxi];nw_z = d3q27_ez[maxi];
+			
+			// Check this isn't pointing towards a solid node:
+			if (solidFlag[maxi] == 1){
+				nw_x = 0.0;
+				nw_y = 0.0;
+				nw_z = 0.0;
 			}
-	  	}
+		}
 	} else {
 	// I am a fluid node, I dont need no solid normal.
 		nw_x = 0.0;nw_y = 0.0;nw_z = 0.0;


### PR DESCRIPTION
- I created explicit variable rather than relying on implicit double to int conversion in Solid Normal calculation.
- I also removed the reliance on integer division in defining values for the solidFlag variable in normal calculation.
- I added a "fix" for edge condition where a solid normal points towards another solid cell. A more robust fix is needed, but this stops the simulation breaking. Was an issue I was finding when importing STL of randomly backed, arbitrary shaped objects from a DEM code I was using. 