### PR TITLE
Correcting typo in GRID3D option

### DIFF
--- a/src/LatticeContainer.inc.cpp.Rt
+++ b/src/LatticeContainer.inc.cpp.Rt
@@ -268,7 +268,7 @@ template <class N> CudaGlobalFunction void RunKernel()
 	now.x_ = CudaThread.x + CudaBlock.z*CudaNumberOfThreads.x + constContainer.dx;
 	now.y_ = CudaThread.y + CudaBlock.x*CudaNumberOfThreads.y + constContainer.dy;
 	now.z_ = CudaBlock.y+constContainer.dz;
-	#ifndef GRID_3D
+	#ifndef GRID3D
 		for (; now.x_ < constContainer.nx; now.x_ += CudaNumberOfThreads.x) {
 	#endif
 		now.Pre();
@@ -278,7 +278,7 @@ template <class N> CudaGlobalFunction void RunKernel()
 			now.OutOfDomain();
 		}
 		now.Glob();
-	#ifndef GRID_3D
+	#ifndef GRID3D
 		}
 	#endif
 }
@@ -445,7 +445,7 @@ template <class N> inline void LatticeContainer::RunInteriorT(CudaStream_t inter
     int nnz;
     ky = ThreadNumber< N >::getKY();
     nnz = fz - dz;
-    #ifdef GRID_3D
+    #ifdef GRID3D
         CudaKernelRunNoWait( RunKernel<N> , dim3(ky, nnz, kx) , dim3(X_BLOCK,ThreadNumber< N >::getSY()),(),interiorStream);
     #else
         CudaKernelRunNoWait( RunKernel<N> , dim3(ky, nnz, 1) , dim3(X_BLOCK,ThreadNumber< N >::getSY()),(),interiorStream);


### PR DESCRIPTION
It turned out that there was a long standing error in the usage of 3D block grid in `LatticeContainer`. This was affecting performance on 2D cases and high-end cards.

This PR fixes this error, but as this wasn't working earlier, and it affects the grid division into blocks, it is important to test it.

If the normal tests will pass, I'll merge it, and then we have to test it for all our applications to see if nothing broke. Things to test (only GPU is relevant):
- [ ] Normal LBM runs (comparison of performance)
- [ ] LBM with finite difference calculations (like two-phase models)
- [ ] Calculation of Globals has to be checked in detail, as this affects the reduction (summation) algorithm.
- [ ] This strongly affects wapr-synchronous actions, so we have to check in great detail if everything still works well with DEM

The performance issue found by @trisbsamson 