### PR TITLE
Adding PercentChange to Stop

### DIFF
--- a/src/Handlers/cbStop.cpp.Rt
+++ b/src/Handlers/cbStop.cpp.Rt
@@ -22,6 +22,8 @@ int cbStop::Init () {
 		        for (g in rows(Globals)) { ?>
 		attr = node.attribute("<?%s g$name ?>Change");
 		if (attr) AddStop(<?%s g$Index ?>, STOP_CHANGE, attr.as_double());
+		attr = node.attribute("<?%s g$name ?>PercentChange");
+		if (attr) AddStop(<?%s g$Index ?>, STOP_PERCENTCHANGE, attr.as_double());
 		attr = node.attribute("<?%s g$name ?>Above");
 		if (attr) AddStop(<?%s g$Index ?>, STOP_ABOVE, attr.as_double());
 		attr = node.attribute("<?%s g$name ?>Below");
@@ -61,6 +63,10 @@ int cbStop::DoIt () {
 				switch (stop_type[i]) {
 				case STOP_CHANGE:
 					if (fabs(old[i] - v) > limit[i]) any++;
+					if (D_MPI_RANK == 0) output("    change:      %4lg < %4lg", fabs(old[i] - v), limit[i]);
+					break;
+				case STOP_PERCENTCHANGE:
+					if (fabs(old[i] - v)/v > limit[i]) any++;
 					if (D_MPI_RANK == 0) output("    change:      %4lg < %4lg", fabs(old[i] - v), limit[i]);
 					break;
 				case STOP_ABOVE:

--- a/src/Handlers/cbStop.cpp.Rt
+++ b/src/Handlers/cbStop.cpp.Rt
@@ -66,8 +66,8 @@ int cbStop::DoIt () {
 					if (D_MPI_RANK == 0) output("    change:      %4lg < %4lg", fabs(old[i] - v), limit[i]);
 					break;
 				case STOP_PERCENTCHANGE:
-					if (fabs(old[i] - v)/v > limit[i]) any++;
-					if (D_MPI_RANK == 0) output("    change:      %4lg < %4lg", fabs(old[i] - v), limit[i]);
+					if (fabs((old[i] - v)/v) > limit[i]) any++;
+					if (D_MPI_RANK == 0) output("    change:    %4lg%% < %4lg%%", 100.0 * fabs((old[i] - v)/v), 100.0 * limit[i]);
 					break;
 				case STOP_ABOVE:
 					if (v < limit[i]) any++;

--- a/src/Handlers/cbStop.h
+++ b/src/Handlers/cbStop.h
@@ -9,6 +9,7 @@
 #define STOP_CHANGE 0x01
 #define STOP_ABOVE 0x02
 #define STOP_BELOW 0x03
+#define STOP_PERCENTCHANGE 0x04
 
 class  cbStop  : public  Callback  {
         std::vector< int > what;


### PR DESCRIPTION
This PR adds and option to stop computation when **percent** change of some global is below some level.

Usage:
```xml
<Stop FluxPercentChange="1%" Times="10" Iterations="10"/>
```
**reminder:** in TCLB `%` is a "unit" equivalent to `0.01`. So you can say `"1e-3"` or `"0.1%"`.

FYI: @TravisMitchell 