### PR TITLE
Adding tapenade to install.sh and tests on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
     - tools/install.sh rinside
     - sudo tools/install.sh python-dev
     - tools/install.sh submodules
-    - "[[ $MODEL =~ _adj$ ]] && tools/install.sh tapenade"
+    - "[[ ! $MODEL =~ _adj$ ]] || tools/install.sh tapenade"
 
 install:
     - nvcc --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ env:
     - MODEL=d3q27 
     - MODEL=d3q27_cumulant 
     - MODEL=d3q27_cumulant_AVG_IB_SMAG
+    - MODEL=d2q9_adj
 
 before_install:
     - tools/install.sh rdep

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_install:
     - tools/install.sh rinside
     - sudo tools/install.sh python-dev
     - tools/install.sh submodules
+    - [[ $MODEL =~ _adj$ ]] && tools/install.sh tapenade
 
 install:
     - nvcc --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
     - tools/install.sh rinside
     - sudo tools/install.sh python-dev
     - tools/install.sh submodules
-    - [[ $MODEL =~ _adj$ ]] && tools/install.sh tapenade
+    - "[[ $MODEL =~ _adj$ ]] && tools/install.sh tapenade"
 
 install:
     - nvcc --version

--- a/src/config.main.mk.in
+++ b/src/config.main.mk.in
@@ -9,6 +9,7 @@ TOOLS = tools
 RT = $(TOOLS)/RT -b
 MKPATH = $(TOOLS)/mkpath
 RS = R --slave --quiet --vanilla -f
+TAPENADE = @TAPENADE@
 ADMOD = tools/ADmod.R
 
 RTOPT=@RTOPT@

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -76,6 +76,10 @@ AC_ARG_WITH([lammps],
 AC_ARG_WITH([lammps-lib],
 	AC_HELP_STRING([--with-lammps-lib=libfile],
 		[specify the name of the lammps/liggghts library (.so/.a)]))
+
+AC_ARG_WITH([tapenade],
+	AC_HELP_STRING([--with-tapenade=path],
+		[use tapenade for code differentiation for adjoint]))
 		
 
 AC_ARG_WITH([verbosity_level],
@@ -655,6 +659,44 @@ then
 	fi
 fi
 
+if test "x${with_tapenade}" != "xno"
+then
+	if test "x${with_tapenade}" == "xyes" || test "x${with_tapenade}" == "x"
+	then
+		if test -f "tapenade/bin/tapenade"
+		then
+			TAPENADE="$PWD/tapenade/bin/tapenade"
+		else
+			TAPENADE="tapenade"
+		fi
+	else
+		if test -d "${with_tapenade}"
+		then
+			TAPENADE="$(cd ${with_tapenade}; pwd)/bin/tapenade"
+		else
+			AC_MSG_ERROR([Path '${with_tapenade}' is not a directory])
+		fi
+	fi
+	
+	
+	AC_MSG_CHECKING([for tapenade])
+	if command -v "${TAPENADE}" >/dev/null 2>&1
+	then
+		AC_MSG_RESULT([yes])
+		TAPENADE="$(command -v "${TAPENADE}")"
+	else
+		AC_MSG_RESULT([no])
+		TAPENADE=""
+		if test "x${with_tapenade}" != "x"
+		then
+			AC_MSG_ERROR([Tapenade '$TAPENADE' is not a valid executable])
+		fi
+	fi
+fi
+		
+		
+
+
 if test "x${enable_debug}" == "xyes"
 then
 	if test "x${with_verbosity_level}" == "x"
@@ -779,6 +821,7 @@ AC_SUBST(CROSS_CPU)
 AC_SUBST(WITH_CATALYST)
 AC_SUBST(WITH_LAMMPS)
 AC_SUBST(WITH_R)
+AC_SUBST(TAPENADE)
 AC_SUBST(PV_VERSION)
 AC_SUBST(RTOPT)
 AC_SUBST(CPP_OPT)

--- a/src/makefile.main.Rt
+++ b/src/makefile.main.Rt
@@ -211,7 +211,7 @@ wiki/schema/<?%s m ?>.xsd:$(SRC)/schema.xsd.Rt $(SRC)/conf.R doc/elements.yaml <
 
 <?%s d ?>/<?%s m ?>/tapenade.run : tools/makeAD <?%s d ?>/<?%s m ?>/Dynamics.c <?%s d ?>/<?%s m ?>/ADpre.h <?%s d ?>/<?%s m ?>/ADpre_b.h <?%s d ?>/<?%s m ?>/Dynamics.h <?%s d ?>/<?%s m ?>/Consts.h <?%s d ?>/<?%s m ?>/types.h <?%s d ?>/<?%s m ?>/ADset.sh <?%s d ?>/<?%s m ?>/ADpost.sed
 	@echo "  TAPENADE   $<"
-	@(cd <?%s d ?>/<?%s m ?>; ../../tools/makeAD)
+	@(cd <?%s d ?>/<?%s m ?>; ../../tools/makeAD "$(TAPENADE)")
 
 <?%s d ?>/<?%s m ?>/dep.mk:tools/dep.R <?%s src ?>
 	@echo "  AUTO-DEP   $@"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -393,6 +393,29 @@ do
 		try "Leaving module directory" cd ..
 		try "Remember to restart terminal" . ~/.bashrc	
 		;;
+	tapenade)
+		if echo "$2" | grep -Eq '^[0-9]*[.][0-9]*$'
+		then
+			shift
+			VER="$1"
+		else
+			VER="3.16"
+		fi
+		if test -d ../tapenade
+		then
+			echo "Looks like tapenade already is installed at '$(cd ../tapenadel; pwd))'"
+			exit -1
+		fi
+		try "Downloading Tapenade ($VER)" wget $WGETOPT http://www-sop.inria.fr/ecuador/tapenade/distrib/tapenade_$VER.tar
+		try "Unpacking Tapenade" tar xf tapenade_$VER.tar
+		if test -d tapenade_$VER
+		then
+			mv tapenade_$VER ../tapenade
+			echo "Installed Tapenade at '$(cd ../tapenade; pwd)'"
+		else
+			echo "Tapenade installation failed"
+		fi
+		;;
 	-*)
 		echo "Unknown option $1" ; usage ;;
 	*)		

--- a/tools/makeAD
+++ b/tools/makeAD
@@ -2,6 +2,19 @@
 
 path_to_script=$(dirname $0)
 #cd package/src
+
+if test -z "$1"
+then
+	TAPENADE="tapenade"
+else
+	TAPENADE="$1"
+fi
+if ! command -v "$TAPENADE"
+then
+	echo "Tapenade not found ('$TAPENADE')" >&2
+	exit -1
+fi
+
 . ADset.sh
 rm Dynamics_tmp.c Dynamics_b.c* ADpre_.h types_b.h tmp 2>/dev/null
 echo "#define CudaDeviceFunction" > Dynamics_tmp.c
@@ -16,11 +29,11 @@ cat Dynamics.c | sed 's/pow(\([^,]*\),3)/((\1)*(\1)*(\1))/g' >> Dynamics_tmp.c
 echo Variables for differentiation: $VARIABLES
 echo Additional variables for differentiation: $SETTINGS
 echo tapenade -html -msglevel 12 -b Dynamics_tmp.c -root $MAIN_FUN -o DynamicsS -vars "$VARIABLES $SETTINGS" -outvars "$VARIABLES $SETTINGS"
-tapenade -msglevel 12 -b Dynamics_tmp.c -root $MAIN_FUN -o DynamicsS -vars "$VARIABLES $SETTINGS" -outvars "$VARIABLES $SETTINGS"
+$TAPENADE -msglevel 12 -b Dynamics_tmp.c -root $MAIN_FUN -o DynamicsS -vars "$VARIABLES $SETTINGS" -outvars "$VARIABLES $SETTINGS"
 echo "#define CONST_SETTINGS" > ADpre_.h
 cat ADpre.h >> ADpre_.h
 echo tapenade -html -msglevel 12 -b Dynamics_tmp.c -root $MAIN_FUN -o DynamicsS -vars "$VARIABLES $SETTINGS" -outvars "$VARIABLES $SETTINGS"
-tapenade -msglevel 12 -b Dynamics_tmp.c -root $MAIN_FUN -o Dynamics -vars "$VARIABLES" -outvars "$VARIABLES"
+$TAPENADE -msglevel 12 -b Dynamics_tmp.c -root $MAIN_FUN -o Dynamics -vars "$VARIABLES" -outvars "$VARIABLES"
 for f in Dynamics_b.c DynamicsS_b.c
 do
 	test -f $f || { echo "Tapenade failed"; exit -1; }


### PR DESCRIPTION
This PR introduces an option to `tools/install.sh` to install tapenade, and adds path discovery and option to `./configure`. It also adds testing of `d2q9_adj` to CI on Travis-CI.