### PR TITLE
+ fix typo in surf force calculation (thermocapillary)

### DIFF
--- a/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
+++ b/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
@@ -529,7 +529,7 @@ CudaDeviceFunction void calc_Fs(real_t *fx, real_t *fy, real_t *fz, real_t mu, v
 		<?R
 			IsotropicGrad('gradT','Temp')
 		?>
-		dotTMP = dotProduct(gradT,gradPhi);
+		dotTMP = dotProduct(gradT,gPhi);
 		if (surfPower < 2) {
 			delta_s = 1.5*IntWidth*sigma_T;
 			*fx = mu * gPhi.x + delta_s*( magnPhi2*gradT.x - dotTMP*gPhi.x );


### PR DESCRIPTION
* Fixed typo in cudadevicefunction calc_Fs(...)

After the clean up of the d3q27_pf_velocity model, the planar benchmark thermocapillary case was not tested. Moving back to this work, I tested and noticed a typo in the thermocapillary surface tension force calculation. This commit fixes and has been tested against the planar benchmark cases 