### PR TITLE
Passing arguments to lammps/liggghts

### DIFF
--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -60,23 +60,59 @@ int main(int argc, char *argv[])
    rfi::RemoteForceInterface< rfi::ForceIntegrator, rfi::RotParticle > RFI;
    RFI.name = "LAMMPS";
 
-   if (argc != 2) {
-     printf("Syntax: lammps in.lammps\n");
+   if (argc < 2) {
+     printf("Syntax: lammps in.lammps [args]\n");
      MPI_Abort(MPI_COMM_WORLD,1);
      exit(1);
    }
-   FILE *fp;
+   std::vector<char*> lammps_args;
+   char * infile = NULL;
+   bool logset = false;
+   for (int i=0; i<argc; i++) {
+     if ((i == 1) && (argv[i][0] != '-')) {
+       infile = argv[i];
+     } else if (strcmp(argv[i],"-in") == 0) {
+       i++;
+       if (i < argc) {
+         infile = argv[i];
+       } else {
+         printf("ERROR: No filename after '-in'\n");
+         MPI_Abort(MPI_COMM_WORLD,1);
+         exit(1);
+       }
+     } else {
+       if (strcmp(argv[i],"-log") == 0) logset = true;
+       lammps_args.push_back(argv[i]);
+     }
+   }
+   if (!logset) {
+     printf("LAMMPS: notice: switching off the default log\n");
+     lammps_args.push_back("-log");
+     lammps_args.push_back("none");
+   }
+
+   if (infile == NULL) {
+     printf("ERROR: No filename provided\n");
+     MPI_Abort(MPI_COMM_WORLD,1);
+     exit(1);
+   }
+   
+   FILE *fp = NULL;
    if (MPMD.local_rank == 0) {
-     fp = fopen(argv[1],"r");
+     printf("LAMMPS: running input file: %s\n", infile);
+     printf("LAMMPS: arguments:");
+     for (int i=1; i<lammps_args.size(); i++) printf(" %s", lammps_args[i]);
+     printf("\n");
+     fp = fopen(infile,"r");
      if (fp == NULL) {
-       printf("ERROR: Could not open LAMMPS input script\n");
+       printf("ERROR: Could not open LAMMPS input script %s\n", infile);
        MPI_Abort(MPI_COMM_WORLD,1);
        exit(1);
      }
    }
 
    LAMMPS *lmp = NULL;
-   lmp = new LAMMPS(0,NULL,MPMD.local);
+   lmp = new LAMMPS(lammps_args.size(),&lammps_args[0],MPMD.local);
 
    int n;
    char line[1024];


### PR DESCRIPTION
This PR improves the lammps/liggghts wrapper by allowing it to pass command line arguments to the DEM solver.

By default `-log none` will be passed to the DEM solver if no `-log` option is provided. Apart from that it is backwards compatible. The wrapper will expect the input file as the first argument, or to follow the `-in` option.

- `lammps file` -- running the `file` with `-log none` options
- `lammps file -log aa` -- running the `file` with `-log aa` options
- `lammps -log aa -in file` -- running the `file` with `-log aa` options
- `lammps -v var 3 -in file` -- running the `file` with `-v var 3 -log none` options

FYI: @ndivaira  I changed the default behaviour to disable `log` output, as it is a crush risk on clusters (and it's kind of useless, as the output is already in the slurm/pbs log).
