### PR TITLE
Correcting the exit from lammps wrapper

### DIFF
--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -160,9 +160,9 @@ int main(int argc, char *argv[])
 
    lammps_close(lmp);
    if (RFI.Connected()) {
-    RFI.Close();
-    MPI_Finalize();
+     RFI.Close();
    }
+   MPI_Finalize();
    return 0;
 }
 


### PR DESCRIPTION
This PR corrects the bug, which caused the lammps/liggghts wrapper to exit improperly when not coupled with TCLB.