### PR TITLE
Non trivially copyable (gcc7.3)

### DIFF
--- a/src/Handlers/cbSaveCheckpoint.cpp
+++ b/src/Handlers/cbSaveCheckpoint.cpp
@@ -63,13 +63,13 @@ int cbSaveCheckpoint::DoIt () {
 				// myqueue should only ever reach the size of keep
 				fileStr = myqueue.front();
 				int rm_result = remove( fileStr.c_str() ); //Takes char
-				if (rm_result != 0) error("Checkpoint file was not deleted: %s",fileStr);
+				if (rm_result != 0) error("Checkpoint file was not deleted: %s",fileStr.c_str());
 				myqueue.pop();
 
 				if (D_MPI_RANK == 0 ) {
 					restStr = myqueue_rst.front();
 					rm_result = remove( restStr.c_str() );
-					if (rm_result != 0) error("Restart file was not deleted: %s",restStr);
+					if (rm_result != 0) error("Restart file was not deleted: %s",restStr.c_str());
 					myqueue_rst.pop();
 				}
 			}


### PR DESCRIPTION
Fix for:
```
make: Okrężna dyrektywa CLB/d3q27_cumulant/makefile <- CLB/d3q27_cumulant/makefile porzucona.
  RT         CLB/d3q27_cumulant/makefile
make[1]: Wejście do katalogu `/lu/tetyda/home/mdzik/rysy/TCLB/CLB/d3q27_cumulant'
  G++        Handlers/cbSaveCheckpoint.cpp
In file included from Handlers/../CommonHandler.h:7:0,
                 from Handlers/cbSaveCheckpoint.h:4,
                 from Handlers/cbSaveCheckpoint.cpp:1:
Handlers/cbSaveCheckpoint.cpp: In member function ‘virtual int cbSaveCheckpoint::DoIt()’:
Handlers/../Global.h:196:50: error: cannot pass objects of non-trivially-copyable type ‘std::string {aka class std::basic_string<char>}’ through ‘...’
     #define debug8(...) myprint(8, 0, __VA_ARGS__) // Error
                                                  ^
Handlers/../Global.h:205:24: note: in expansion of macro ‘debug8’
     #define error(...) debug8(__VA_ARGS__)    
                        ^
Handlers/cbSaveCheckpoint.cpp:66:25: note: in expansion of macro ‘error’
     if (rm_result != 0) error("Checkpoint file was not deleted: %s",fileStr);
                         ^
Handlers/../Global.h:196:50: error: cannot pass objects of non-trivially-copyable type ‘std::string {aka class std::basic_string<char>}’ through ‘...’
     #define debug8(...) myprint(8, 0, __VA_ARGS__) // Error
                                                  ^
Handlers/../Global.h:205:24: note: in expansion of macro ‘debug8’
     #define error(...) debug8(__VA_ARGS__)    
                        ^
Handlers/cbSaveCheckpoint.cpp:72:26: note: in expansion of macro ‘error’
      if (rm_result != 0) error("Restart file was not deleted: %s",restStr);
                          ^
make[1]: *** [Handlers/cbSaveCheckpoint.o] Błąd 1
make[1]: Opuszczenie katalogu `/lu/tetyda/home/mdzik/rysy/TCLB/CLB/d3q27_cumulant'
make: *** [CLB/d3q27_cumulant/main] Błąd 2


```

```
Currently Loaded Modulefiles:
 1) common/R/4.0.3   2) gpu/cuda/10.0   3) common/mpi/openmpi/4.0.4_gnu-7.3  

```

