### PR TITLE
Reduce logging

### DIFF
--- a/src/Geometry.cpp.Rt
+++ b/src/Geometry.cpp.Rt
@@ -956,7 +956,7 @@ int Geometry::Draw(pugi::xml_node & node)
 	reg.nx = 2*Rx + 10;
 	reg.ny = 2*Ry + 10;
 
-	    debug1("Filling YPipe with flag %d (%d)\n, with center at (%lf,%lfi,%f) radius (%lf,%lf)", fg, fg_mask, x0, y0, z0, Rx, Rz);
+	    debug1("Filling YPipe with flag %d (%d)\n, with center at (%lf,%lfi,%f) radius (%lf,%lf)", fg, fg_mask, x0, y0, z0, Rx, Ry);
 	    DEBUG1(reg.print();)
 		for (int y = reg.dy; y < reg.dy + reg.ny; y++)
 		for (int z = reg.dz; z < reg.dz + reg.nz; z++)

--- a/src/pinned_allocator.hpp
+++ b/src/pinned_allocator.hpp
@@ -32,7 +32,7 @@ public:
                         return;
                 }
 
-                pinned_allocator() throw(): std::allocator<T>() { fprintf(stderr, "Hello allocator!\n"); }
+                pinned_allocator() throw(): std::allocator<T>() { debug0("Creating pinned allocator...\n"); }
                 pinned_allocator(const pinned_allocator &a) throw(): std::allocator<T>(a) { }
                 template <class U>                    
                 pinned_allocator(const pinned_allocator<U> &a) throw(): std::allocator<T>(a) { }


### PR DESCRIPTION
Printing in `pinned_allocator.hpp` was quite annoying, especially when running on CPUs. 

Additionally, when testing turned out that I could not compile with verbosity level 0, due to the undefined variable in `Geometry.cpp.Rt`, so I've fixed that as well. 