### PR TITLE
Fix broken CI

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -9,135 +9,135 @@ AC_CONFIG_HEADERS([CLB/config.h:src/config.h.in])
 AC_LANG([C++])
 
 AC_ARG_WITH([gcc],
-	AC_HELP_STRING([--with-gcc=compiler_bindir],
+	AS_HELP_STRING([--with-gcc=compiler_bindir],
 		[specify the directory containing gcc, e.g. /usr/bin]),
 	[COMPILER_BINDIR="$withval"])
 
 AC_ARG_ENABLE([cuda],
-	AC_HELP_STRING([--enable-cuda=cuda_home],
+	AS_HELP_STRING([--enable-cuda=cuda_home],
 		[specify the root of your cuda install, e.g. /usr/local/cuda]))
 
 AC_ARG_WITH([mpi-include],
-	AC_HELP_STRING([--with-mpi-include=mpi_include],
+	AS_HELP_STRING([--with-mpi-include=mpi_include],
 		[specify the full path to your mpi headers, e.g. /usr/include/mpi]),
 	[MPI_INCLUDE="$withval"])
 
 AC_ARG_WITH([mpi-lib],
-	AC_HELP_STRING([--with-mpi-lib=mpi_lib],
+	AS_HELP_STRING([--with-mpi-lib=mpi_lib],
 		[specify the full path to your mpi shared libraries, e.g. /usr/lib/openmpi/]),
 	[MPI_LIB="$withval"])
 
 AC_ARG_WITH([hdf5],
-	AC_HELP_STRING([--with-hdf5=hdf5],
+	AS_HELP_STRING([--with-hdf5=hdf5],
 		[specify the full path to your hdf5 installation]))
 AC_ARG_WITH([hdf5-lib],
-	AC_HELP_STRING([--with-hdf5-lib=hdf5],
+	AS_HELP_STRING([--with-hdf5-lib=hdf5],
 		[specify the full path to your hdf5 installation (libraries)]))
 AC_ARG_WITH([hdf5-include],
-	AC_HELP_STRING([--with-hdf5-include=hdf5],
+	AS_HELP_STRING([--with-hdf5-include=hdf5],
 		[specify the full path to your hdf5 installation (headers)]))
 
 AC_ARG_WITH([eigen],
-	AC_HELP_STRING([--with-eigen=eigen],
+	AS_HELP_STRING([--with-eigen=eigen],
 		[specify the full path to your Eigen installation (headers)]))
 
 AC_ARG_ENABLE([graphics],
-	AC_HELP_STRING([--enable-graphics],
+	AS_HELP_STRING([--enable-graphics],
 		[make a GUI version]))
 
 AC_ARG_ENABLE([double],
-	AC_HELP_STRING([--enable-double],
+	AS_HELP_STRING([--enable-double],
 		[make a double precision version]))
 
 AC_ARG_ENABLE([cpp11],
-	AC_HELP_STRING([--enable-cpp11],
+	AS_HELP_STRING([--enable-cpp11],
 		[enable C++ 11 standard]))
 
 AC_ARG_WITH([cuda-arch],
-	AC_HELP_STRING([--with-cuda-arch=arch],
+	AS_HELP_STRING([--with-cuda-arch=arch],
 		[specify the desired CUDA architecture (sm_11/sm_13/sm_20/sm_30/sm_60/sm_75/sm_80)]))
 
 AC_ARG_WITH([nlopt],
-	AC_HELP_STRING([--with-nlopt=nlopt],
+	AS_HELP_STRING([--with-nlopt=nlopt],
 		[specify the full path to your nlopt library]))
 
 AC_ARG_WITH([r],
-	AC_HELP_STRING([--with-r=r],
+	AS_HELP_STRING([--with-r=r],
 		[specify the full path to your r]))
 
 AC_ARG_ENABLE([rinside],
-	AC_HELP_STRING([--enable-rinside],
+	AS_HELP_STRING([--enable-rinside],
 		[specify the full path to your r]))
 
 AC_ARG_WITH([catalyst],
-	AC_HELP_STRING([--with-catalyst=path],
+	AS_HELP_STRING([--with-catalyst=path],
 		[specify the full path to your paraview source and build]))
 
 AC_ARG_WITH([lammps],
-	AC_HELP_STRING([--with-lammps=path],
+	AS_HELP_STRING([--with-lammps=path],
 		[specify the full path to your LAMMPS/LIGGGHTS directory]))
 
 AC_ARG_WITH([lammps-lib],
-	AC_HELP_STRING([--with-lammps-lib=libfile],
+	AS_HELP_STRING([--with-lammps-lib=libfile],
 		[specify the name of the lammps/liggghts library (.so/.a)]))
 
 AC_ARG_WITH([tapenade],
-	AC_HELP_STRING([--with-tapenade=path],
+	AS_HELP_STRING([--with-tapenade=path],
 		[use tapenade for code differentiation for adjoint]))
 		
 
 AC_ARG_WITH([verbosity_level],
-	AC_HELP_STRING([--with-verbosity-level=level],
+	AS_HELP_STRING([--with-verbosity-level=level],
 		[specify level of debug messages 0-all, 1-much, 2-some, 3-normal]))
 
 AC_ARG_ENABLE([debug],
-	AC_HELP_STRING([--enable-debug],
+	AS_HELP_STRING([--enable-debug],
 		[enables debug version (gcc -g)]))
 
 AC_ARG_ENABLE([waitany],
-	AC_HELP_STRING([--enable-waitany],
+	AS_HELP_STRING([--enable-waitany],
 		[enables MPI WaitAny (default)]))
 
 AC_ARG_WITH([openmp],
-	AC_HELP_STRING([--with-openmp],
+	AS_HELP_STRING([--with-openmp],
 		[enable openMP in the CPU code]))
 
 AC_ARG_ENABLE([coverage],
-	AC_HELP_STRING([--enable-coverage],
+	AS_HELP_STRING([--enable-coverage],
 		[enable coverage testing]))
 
 AC_ARG_ENABLE([marklines],
-	AC_HELP_STRING([--enable-marklines],
+	AS_HELP_STRING([--enable-marklines],
 		[enable marking lines with pragma in RT]))
 
 AC_ARG_ENABLE([debug-kernel],
-	AC_HELP_STRING([--with-debug-kernel],
+	AS_HELP_STRING([--with-debug-kernel],
 		[enable NVCC pos compile stats for debug (lots of output!)]))
 
 AC_ARG_WITH([python],
-	AC_HELP_STRING([--with-python],
+	AS_HELP_STRING([--with-python],
 		[Enable CallPython handler, requires python-dev]))
 
 AC_ARG_WITH([python_config],
-	AC_HELP_STRING([--with-python-config],
+	AS_HELP_STRING([--with-python-config],
 		[Set python-config binary to call]))
 
 AC_ARG_WITH([python_bin],
-	AC_HELP_STRING([--with-python-bin],
+	AS_HELP_STRING([--with-python-bin],
 		[Set python binary to call]))
 
 AC_ARG_ENABLE([paranoid],
-	AC_HELP_STRING([--enable-paranoid],
+	AS_HELP_STRING([--enable-paranoid],
 		[Makes GCC paranoid.]))
 AC_ARG_ENABLE([profiling],
-	AC_HELP_STRING([--enable-profiling],
+	AS_HELP_STRING([--enable-profiling],
 		[enable profiling for R in rtemplate]))		
 AC_ARG_ENABLE([keepcode],
-	AC_HELP_STRING([--enable-keepcode],
+	AS_HELP_STRING([--enable-keepcode],
 		[keeps the R code for rtemplate along with the generated file]))
 
 AC_ARG_WITH([cpp-flags],
-	AC_HELP_STRING([--with-cpp-flags=FLAGS],
+	AS_HELP_STRING([--with-cpp-flags=FLAGS],
 		[privide additionals flags for the compiler]),
 	[CONF_CPPFLAGS="$withval"])		
 NVFLAGS=""


### PR DESCRIPTION
Use `AS_HELP_STRING` instead of `AC_HELP_STRING`. 

`AC_HELP_STRING` is really deprecated in autoconf 2.70+ (which is one installed by macOS it seems, that is why CI was not working). `AS_HELP_STRING` is already available since autotoconf 2.60 at least (which was released in 2006, and most of systems use at least autoconf 2.69, so it safe to use). 

For similar issues see e.g: 
- https://midnight-commander.org/ticket/2560 
- https://github.com/curl/curl/issues/6647 