### PR TITLE
Correcting the exit from simplepart

### DIFF
--- a/src/simplepart.cpp
+++ b/src/simplepart.cpp
@@ -301,7 +301,7 @@ int main(int argc, char *argv[]) {
   if (logging && (logging_f != NULL)) fclose(logging_f);
   if (RFI.Connected()) {
     RFI.Close();
-    MPI_Finalize();
   }
+  MPI_Finalize();
   return 0;
 }


### PR DESCRIPTION
This PR corrects the bug, which caused the simplepart to exit improperly and making a coupled simulation hand indefinitely.

Fixes #388 