### PR TITLE
Fix HalfSphere geometry

### DIFF
--- a/src/Geometry.cpp.Rt
+++ b/src/Geometry.cpp.Rt
@@ -767,7 +767,7 @@ int Geometry::Draw(pugi::xml_node & node)
 		for (int x = reg.dx; x < reg.dx + reg.nx; x++)
 		for (int y = reg.dy; y < reg.dy + reg.ny; y++)
 		    for (int z = reg.dz; z < reg.dz + reg.nz; z++) {
-			if (inSphere((.5 + x - reg.dx) / reg.nx, 0.5 - (y - .5  - reg.dy) / reg.ny / 2., (.5 + z - reg.dz) / reg.nz) ) {
+			if (inSphere((.5 + x - reg.dx) / reg.nx, 0.5 - (.5 + y - reg.dy) / reg.ny / 2., (.5 + z - reg.dz) / reg.nz) ) {
 			    Dot(x, y, z);
 			}
 		    }


### PR DESCRIPTION
I believe it should be plus instead of minus there, otherwise the shape is incorrect

1. Sphere ![sphere](https://user-images.githubusercontent.com/13331189/167522862-f49d4edf-2ac3-4671-b864-e7c964f7cb8c.png)
2. Half sphere without the fix (look at the top) ![half_sphere_old](https://user-images.githubusercontent.com/13331189/167522857-da9ca6c7-3103-4db1-8507-6c032192f0de.png)
3. Half sphere with the fix ![half_sphere_proper](https://user-images.githubusercontent.com/13331189/167522856-f1578963-75aa-45a9-a1cc-62be89d6923f.png)
 