### PR TITLE
Export iteration number to Rinside

### DIFF
--- a/src/Handlers/cbRunR.cpp.Rt
+++ b/src/Handlers/cbRunR.cpp.Rt
@@ -303,6 +303,7 @@ public:
 	}
 	Rcpp::CharacterVector Names() {
 		Rcpp::CharacterVector ret;
+		ret.push_back("Iteration");
 		<?R for (q in rows(Globals)) { ifdef(q$adjoint); ?>
 		ret.push_back("<?%s q$name ?>");
 		ret.push_back("<?%s q$name ?>.si");

--- a/src/Handlers/cbRunR.cpp.Rt
+++ b/src/Handlers/cbRunR.cpp.Rt
@@ -281,6 +281,10 @@ public:
 	std::string print() { return "Globals"; }
 	SEXP Dollar(std::string name) {
 		Rcpp::NumericVector ret(1);
+		if (name == "Iteration") {
+			ret[0] = solver->lattice->Iter;
+			return ret;
+		}
 	<?R 
 		for (q in rows(Globals)) { ifdef(q$adjoint);
 	?>


### PR DESCRIPTION
Makes much easier generating files associated with the current iteration (e.g. I used it to generate pictures of "slices" data and saving into files with filename based on the iteration)


Not sure, where exactly it should be, I put it into `Solver$Globals` , because it made more sense than `Solver$Iteration$`, but suggestions are welcome
