### PR TITLE
Fix leak in Sampler

### DIFF
--- a/src/Sampler.cpp.Rt
+++ b/src/Sampler.cpp.Rt
@@ -90,6 +90,7 @@ int Sampler::Finish()
  CudaFree(gpu_buffer);
  size = 0;
  startIter = 0;
+ spoints.clear();
  lbRegion pos;
  position = pos;
  return 0;


### PR DESCRIPTION
During using Sampler I realised that added points are not cleared on finalising. This means next time `Sampler` is used (e.g. if used inside  two successive `Solve` handlers) previous points from the previous Sampler would still be there and would be unexpectedly present in the output.

This fixes it. 