### PR TITLE
Correcting float compilation

### DIFF
--- a/src/Particle.hpp
+++ b/src/Particle.hpp
@@ -97,7 +97,7 @@ struct ParticleS : ParticleI {
 		atomicSumWarp(&constContainer.particle_data[i*RFI_DATA_SIZE+RFI_DATA_MOMENT+0],moment.x);
 		atomicSumWarp(&constContainer.particle_data[i*RFI_DATA_SIZE+RFI_DATA_MOMENT+1],moment.y);
 		atomicSumWarp(&constContainer.particle_data[i*RFI_DATA_SIZE+RFI_DATA_MOMENT+2],moment.z);*/
-		double val[6] = {force.x,force.y,force.z,moment.x,moment.y,moment.z};
+		real_t val[6] = {force.x,force.y,force.z,moment.x,moment.y,moment.z};
 		atomicSumWarpArr(&constContainer.particle_data[i*RFI_DATA_SIZE+RFI_DATA_FORCE],val,6);
 #elif PARTICLE_SYNC == BLOCK_SYNC
 		atomicSum(&constContainer.particle_data[i*RFI_DATA_SIZE+RFI_DATA_FORCE+0],force.x);

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -14,12 +14,13 @@
 using namespace LAMMPS_NS;
 
 
+typedef rfi::RemoteForceInterface< rfi::ForceIntegrator, rfi::RotParticle, rfi::ArrayOfStructures, real_t > RFI_t;
 
 struct Info {
    MPMDHelper *MPMD;
    Memory *memory;
    LAMMPS *lmp;
-   rfi::RemoteForceInterface< rfi::ForceIntegrator, rfi::RotParticle > * RFI;
+   RFI_t * RFI;
    std::vector<size_t> wsize;
    std::vector<size_t> windex;
 };
@@ -57,7 +58,7 @@ int main(int argc, char *argv[])
    DEBUG_SETRANK(MPMD.local_rank);
    InitPrint(DEBUG_LEVEL, 6, 8);
    MPMD.Identify();
-   rfi::RemoteForceInterface< rfi::ForceIntegrator, rfi::RotParticle > RFI;
+   RFI_t RFI;
    RFI.name = "LAMMPS";
 
    if (argc < 2) {


### PR DESCRIPTION
This PR fixes errors in compilation that happen when compiled with `--disable-double` introduced while DEM was introduced.