### PR TITLE
Adding position to lattice

### DIFF
--- a/src/Handlers/acGeometry.cpp
+++ b/src/Handlers/acGeometry.cpp
@@ -3,6 +3,16 @@ std::string acGeometry::xmlname = "Geometry";
 #include "../HandlerFactory.h"
 
 int acGeometry::Init () {
+		double px=0.0, py=0.0, pz=0.0;
+		bool write_pos = false;
+		pugi::xml_attribute attr;
+		attr = node.attribute("px");
+		if (attr) { px = solver->units.alt(attr.value()); write_pos = true; }
+		attr = node.attribute("py");
+		if (attr) { py = solver->units.alt(attr.value()); write_pos = true; }
+		attr = node.attribute("pz");
+		if (attr) { pz = solver->units.alt(attr.value()); write_pos = true; }
+		if (write_pos) solver->lattice->setPosition(px,py,pz);
 			if (solver->geometry->load(node)) {
 				error("Error while loading geometry\n");
 				return -1;

--- a/src/Handlers/acRemoteForceInterface.cpp
+++ b/src/Handlers/acRemoteForceInterface.cpp
@@ -58,7 +58,16 @@ int acRemoteForceInterface::ConnectRemoteForceInterface(std::string integrator_)
         
         if (use_box) {
           lbRegion reg = solver->lattice->region;
-          solver->lattice->RFI.DeclareSimpleBox(reg.dx, reg.dx+reg.nx, reg.dy, reg.dy+reg.ny, reg.dz, reg.dz+reg.nz);
+          double px = solver->lattice->px;
+          double py = solver->lattice->py;
+          double pz = solver->lattice->pz;
+          solver->lattice->RFI.DeclareSimpleBox(
+            px + reg.dx,
+            px + reg.dx + reg.nx,
+            py + reg.dy,
+            py + reg.dy + reg.ny,
+            pz + reg.dz,
+            pz + reg.dz + reg.nz);
         }
         MPI_Barrier(MPMD.local);
         solver->lattice->RFI.Connect(MPMD.work,inter.work);

--- a/src/Lattice.cu.Rt
+++ b/src/Lattice.cu.Rt
@@ -59,6 +59,17 @@ int SnapLevel(unsigned int i) {
 	return w;
 }
 
+/// Set position
+void Lattice::setPosition(double px_, double py_, double pz_)
+{
+	px = px_;
+	py = py_;
+	pz = pz_;
+	container->px = px + 0.5 + region.dx;
+	container->py = py + 0.5 + region.dy;
+	container->pz = pz + 0.5 + region.dz;
+}
+
 /// Calculation of the offset from X, Y and Z
 int Lattice::Offset(int x, int y, int z)
 {
@@ -87,9 +98,7 @@ Lattice::Lattice(lbRegion _region, MPIInfo mpi_, int ns):region(_region), mpi(mp
 	Snaps = new FTabs[nSnaps];
 	iSnaps = new int[maxSnaps];
 	container->Alloc(_region.nx,_region.ny,_region.nz);
-	container->px = region.dx;
-	container->py = region.dy;
-	container->pz = region.dz;
+	setPosition(0.0,0.0,0.0);
 	container->iter = 0;
 	container->reset_iter = 0;
 	DEBUG_M;

--- a/src/Lattice.h.Rt
+++ b/src/Lattice.h.Rt
@@ -74,6 +74,7 @@ public:
   real_t settings[SETTINGS];  ///< Table of Settings (Now)
   double globals[GLOBALS]; ///< Table of Globals
   lbRegion region; ///< Local lattice region
+  real_t px, py, pz; 
   MPIInfo mpi; ///< MPI information
   typedef rfi::RemoteForceInterface< rfi::ForceCalculator, rfi::RotParticle, rfi::ArrayOfStructures, real_t, pinned_allocator<real_t> > rfi_t;
   rfi_t RFI;
@@ -87,6 +88,7 @@ public:
   void MPIInit (MPIInfo);
   void Color(uchar4 *);
   int Offset(int,int,int);
+  void setPosition(double, double, double);
   void FlagOverwrite(flag_t *, lbRegion);
   void CutsOverwrite(cut_t * Q, lbRegion over);
   void Init();

--- a/src/LatticeContainer.h.Rt
+++ b/src/LatticeContainer.h.Rt
@@ -55,7 +55,7 @@ class LatticeContainer {
   int fx, fy, fz; ///< End of the region to calculate in the interior kernel run
   int kx,ky; ///< X and Y thread division
   int iter; ///< Iteration number
-	int px,py,pz;
+  real_t px,py,pz;
   int reset_iter; //< number of last average reset,for dynamics 
   int ZoneIndex;
   int MaxZones;

--- a/src/cuda.cu.Rt
+++ b/src/cuda.cu.Rt
@@ -59,9 +59,9 @@ CudaDeviceFunction CudaConstantMemory real_t <?%s v$name ?> = 0.0f; <?R
         }
 ?>
 
-#define X ((real_t) x_ + constContainer.px + 0.5)
-#define Y ((real_t) y_ + constContainer.py + 0.5)
-#define Z ((real_t) z_ + constContainer.pz + 0.5)
+#define X (constContainer.px + x_)
+#define Y (constContainer.px + y_)
+#define Z (constContainer.px + z_)
 #define Time (constContainer.iter)
 #define SyntheticTurbulence(x__,y__,z__) constContainer.getST(x__,y__,z__)
 #define average_iter (constContainer.iter - constContainer.reset_iter)  //Look nicer in Dynamics

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -65,10 +65,10 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 	xdmf_dataitem.append_attribute("Dimensions") = "3";
 	xdmf_dataitem.append_attribute("Format") = "XML";
 	xdmf_dataitem.append_attribute("Precision") = 8;
-	if (options & HDF5_WRITE_POINT) {
-		xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(" ") << 0.5/unit << 0.5/unit << 0.5/unit);
-	} else {
-		xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(" ") << 0 << 0 << 0);
+	{
+		double shift = 0.0
+		if (options & HDF5_WRITE_POINT) shift = 0.5;
+		xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(" ") << (lattice->px + shift)/unit << (lattice->py + shift)/unit << (lattice->pz + 0.5)/unit);
 	}
 	xdmf_dataitem = xdmf_geometry.append_child("DataItem");
 	xdmf_dataitem.append_attribute("DataType") = "Float";

--- a/src/vtkLattice.cpp.Rt
+++ b/src/vtkLattice.cpp.Rt
@@ -22,7 +22,7 @@ int vtkWriteLattice(char * filename, Lattice * lattice, UnitEnv units, name_set 
 	vtkFileOut vtkFile(MPMD.local);
 	if (vtkFile.Open(filename)) {return -1;}
 	double spacing = 1/units.alt("m");	
-	vtkFile.Init(lattice->mpi.totalregion, reg, "Scalars=\"rho\" Vectors=\"velocity\"", spacing);
+	vtkFile.Init(lattice->mpi.totalregion, reg, "Scalars=\"rho\" Vectors=\"velocity\"", spacing, lattice->px*spacing, lattice->py*spacing, lattice->pz*spacing);
 
 	{	flag_t * NodeType = new flag_t[size];
 		lattice->GetFlags(reg, NodeType);

--- a/src/vtkOutput.cpp
+++ b/src/vtkOutput.cpp
@@ -96,14 +96,15 @@ void vtkFileOut::WriteB64(void * tab, int len) {
 	fprintB64(f, tab, len);
 };
 
-void vtkFileOut::Init(lbRegion regiontot, lbRegion region, char* selection, double spacing) {
+void vtkFileOut::Init(lbRegion regiontot, lbRegion region, char* selection, double spacing, double px, double py, double pz) {
 	FERR;
 	size = region.size();
 	fprintf(f, "<?xml version=\"1.0\"?>\n<VTKFile type=\"ImageData\" version=\"0.1\" byte_order=\"LittleEndian\">\n");
-	fprintf(f, "<ImageData WholeExtent=\"%d %d %d %d %d %d\" Origin=\"0 0 0\" Spacing=\"%lg %lg %lg\">\n",
+	fprintf(f, "<ImageData WholeExtent=\"%d %d %d %d %d %d\" Origin=\"%lg %lg %lg\" Spacing=\"%lg %lg %lg\">\n",
 		region.dx, region.dx + region.nx,
 		region.dy, region.dy + region.ny,
 		region.dz, region.dz + region.nz,
+		px, py, pz,
 		spacing,
 		spacing,
 		spacing
@@ -116,10 +117,11 @@ void vtkFileOut::Init(lbRegion regiontot, lbRegion region, char* selection, doub
 	fprintf(f, "<CellData %s>\n", selection);
 	if (fp != NULL) {
 		fprintf(fp, "<?xml version=\"1.0\"?>\n<VTKFile type=\"PImageData\" version=\"0.1\" byte_order=\"LittleEndian\">\n");
-		fprintf(fp, "<PImageData WholeExtent=\"%d %d %d %d %d %d\" Origin=\"0 0 0\" Spacing=\"%lg %lg %lg\">\n",
+		fprintf(fp, "<PImageData WholeExtent=\"%d %d %d %d %d %d\" Origin=\"%lg %lg %lg\" Spacing=\"%lg %lg %lg\">\n",
 			regiontot.dx, regiontot.dx + regiontot.nx,
 			regiontot.dy, regiontot.dy + regiontot.ny,
 			regiontot.dz, regiontot.dz + regiontot.nz,
+			px, py, pz,
 			spacing,
 			spacing,
 			spacing
@@ -149,15 +151,6 @@ void vtkFileOut::Init(lbRegion regiontot, lbRegion region, char* selection, doub
 		fprintf(fp, "<PCellData %s>\n", selection);
 	}
 };
-
-void vtkFileOut::Init(lbRegion region, char* selection) {
-	Init(region, region, selection);
-
-//	FERR;
-//	size = region.size();
-//	fprintf(f, vtk_header, region.nx -1, region.ny -1, region.nz -1, region.nx -1, region.ny -1, region.nz -1,  selection);
-};
-
 
 void vtkFileOut::Init(int width, int height) {
 	Init(lbRegion(0,0,0,width,height,1),"");

--- a/src/vtkOutput.h
+++ b/src/vtkOutput.h
@@ -16,9 +16,10 @@ public:
 	vtkFileOut (MPI_Comm comm_=MPI_COMM_WORLD);
 	int Open(const char* filename);
 	void WriteB64(void * tab, int len);
-	void Init(lbRegion region, char* selection);
-	void Init(lbRegion, lbRegion region, char* selection, double spacing);
+	void Init(lbRegion, lbRegion region, char* selection, double spacing, double, double, double);
+	inline void Init(lbRegion region, char* selection) { Init(region, region, selection); }
 	inline void Init(lbRegion tot, lbRegion region, char* selection) { Init(tot, region, selection, 0.05); }
+	inline void Init(lbRegion tot, lbRegion region, char* selection, double spacing) { Init( tot, region, selection, spacing, 0.0, 0.0, 0.0); }
 	void Init(int width, int height);
 	void WriteField(char * name, void * data, int elem, char * tp, int components);
 	inline void WriteField(char * name, float * data) { WriteField(name, (void*) data, sizeof(float), "Float32", 1); };


### PR DESCRIPTION
Adding the option to shift the position of the lattice. It's a long overdue thing. You can set the position with `px`, `py` and `pz` arguments in the `<Geometry>` element.

The position affects:
- the `X`, `Y` and `Z` values in calculations
- the VTK export (it will be specially shifted)
- particle coupling

This does not affect:
- geometry elements like `<Box>`, `<Sphere>` or even `<STL>`. All geometry is in relation to the lattice origin.