### PR TITLE
Adding support for LIGGGHTS-PFM

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -608,7 +608,7 @@ then
 	LAMMPS="$(cd $LAMMPS; pwd)"
 	mkdir -p $LAMMPS/install/include/lammps
 	mkdir -p $LAMMPS/install/lib/
-	for i in lammps.h library.h input.h modify.h fix.h fix_external.h pointers.h lmptype.h lmpwindows.h atom.h domain.h
+	for i in lammps.h library.h input.h modify.h fix.h fix_external.h pointers.h lmptype.h lmpwindows.h atom.h domain.h partitioner.h
 	do
 		rm ${LAMMPS}/install/include/lammps/${i} 2>/dev/null
 		AC_CHECK_FILE([${LAMMPS}/src/${i}], [ln -s ../../../src/${i} ${LAMMPS}/install/include/lammps/${i}],[AC_MSG_ERROR([Cannot find ${i}])])
@@ -620,16 +620,20 @@ then
 	done
 	if test "x${with_lammps_lib}" == "x"
 	then
-		LAMMPS_LIB="liblammps.so"
-		if test -L ${LAMMPS}/src/libliggghts.so
-		then
-			echo "It's LIGGGHTS we're working with"
-			LAMMPS_LIB="libliggghts.so"
-		fi
+		for LAMMPS_LIB_DIR in build src
+		do
+			for LAMMPS_LIB in libliggghts.so liblammps.so
+			do
+				if test -f "${LAMMPS}/${LAMMPS_LIB_DIR}/${LAMMPS_LIB}"
+				then
+					break 2
+				fi
+			done
+		done
 	else
 		LAMMPS_LIB="${with_lammps_lib}"
 	fi
-	AC_CHECK_FILE([${LAMMPS}/src/$LAMMPS_LIB], [ln -s ../../src/$LAMMPS_LIB ${LAMMPS}/install/lib/$LAMMPS_LIB],[AC_MSG_ERROR([Cannot find $LAMMPS_LIB])])
+	AC_CHECK_FILE([${LAMMPS}/$LAMMPS_LIB_DIR/$LAMMPS_LIB], [ln -s ../../$LAMMPS_LIB_DIR/$LAMMPS_LIB ${LAMMPS}/install/lib/$LAMMPS_LIB],[AC_MSG_ERROR([Cannot find $LAMMPS_LIB])])
 	LDFLAGS="${LDFLAGS} -L${LAMMPS}/install/lib -Wl,-rpath=${LAMMPS}/install/lib"
 	CPPFLAGS="${CPPFLAGS} -I${LAMMPS}/install/include"
 	LAMMPS_LIB_NAME=${LAMMPS_LIB#lib}

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -608,10 +608,15 @@ then
 	LAMMPS="$(cd $LAMMPS; pwd)"
 	mkdir -p $LAMMPS/install/include/lammps
 	mkdir -p $LAMMPS/install/lib/
-	for i in lammps.h library.h input.h modify.h fix.h fix_external.h pointers.h lmptype.h lmpwindows.h atom.h domain.h partitioner.h
+	for i in lammps.h library.h input.h modify.h fix.h fix_external.h pointers.h lmptype.h lmpwindows.h atom.h domain.h
 	do
 		rm ${LAMMPS}/install/include/lammps/${i} 2>/dev/null
 		AC_CHECK_FILE([${LAMMPS}/src/${i}], [ln -s ../../../src/${i} ${LAMMPS}/install/include/lammps/${i}],[AC_MSG_ERROR([Cannot find ${i}])])
+	done
+	for i in partitioner.h
+	do
+		rm ${LAMMPS}/install/include/lammps/${i} 2>/dev/null
+		AC_CHECK_FILE([${LAMMPS}/src/${i}], [ln -s ../../../src/${i} ${LAMMPS}/install/include/lammps/${i}],[])
 	done
 
 	for i in error.h comm.h vector_liggghts.h neighbor.h math_extra_liggghts.h domain_I.h


### PR DESCRIPTION
This PR modifies configure script to correctly discover [LIGGGHTS-PFM](https://github.com/ParticulateFlow/LIGGGHTS-PFM) as DEM solver. Now both `build/` and `src/` paths are searched for the library file.

FYI: @ndivaira 