### PR TITLE
Changing macro name to avoid name-collision with Rcpp

### DIFF
--- a/src/LatticeAccess.inc.cpp.Rt
+++ b/src/LatticeAccess.inc.cpp.Rt
@@ -10,17 +10,17 @@
 #include "Lattice.h"
 #include <mpi.h>
 
-#ifndef STORAGE_TYPE
+#ifndef STORAGE_BITS
   #define storage_to_real(x__) x__
   #define real_to_storage(x__) x__
-#elif STORAGE_TYPE == 16
+#elif STORAGE_BITS == 16
   #include <cuda_fp16.h>
   inline CudaDeviceFunction real_t storage_to_real(storage_t v) { return __short_as_half(v); }
   inline CudaDeviceFunction storage_t real_to_storage(real_t v) { return __half_as_short(v); }
-#elif STORAGE_TYPE == 32
+#elif STORAGE_BITS == 32
   inline CudaDeviceFunction real_t storage_to_real(storage_t v) { return __int_as_float(v); }
   inline CudaDeviceFunction storage_t real_to_storage(real_t v) { return __float_as_int(v); }
-#elif STORAGE_TYPE == 64
+#elif STORAGE_BITS == 64
   inline CudaDeviceFunction real_t storage_to_real(storage_t v) { return __longlong_as_double(v); }
   inline CudaDeviceFunction storage_t real_to_storage(real_t v) { return __double_as_longlong(v); }
 #endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -18,7 +18,7 @@
 #undef CALC_DOUBLE_PRECISION
 
 /* Storage type used */
-#undef STORAGE_TYPE
+#undef STORAGE_BITS
 
 /* Using shift for storage */
 #undef STORAGE_SHIFT

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -195,21 +195,21 @@ fi
 
 if test "x${with_storage}" == "xhalf-shift"
 then
-	AC_DEFINE([STORAGE_TYPE], [16], [Using half as storage])
+	AC_DEFINE([STORAGE_BITS], [16], [Using half as storage])
 	AC_DEFINE([STORAGE_SHIFT], [1], [Using shift for storage])
 elif test "x${with_storage}" == "xhalf"
 then
-	AC_DEFINE([STORAGE_TYPE], [16], [Using half as storage])
+	AC_DEFINE([STORAGE_BITS], [16], [Using half as storage])
 elif test "x${with_storage}" == "xfloat-shift"
 then
-	AC_DEFINE([STORAGE_TYPE], [32], [Using half as storage])
+	AC_DEFINE([STORAGE_BITS], [32], [Using half as storage])
 	AC_DEFINE([STORAGE_SHIFT], [1], [Using shift for storage])
 elif test "x${with_storage}" == "xfloat"
 then
-	AC_DEFINE([STORAGE_TYPE], [32], [Using half as storage])
+	AC_DEFINE([STORAGE_BITS], [32], [Using half as storage])
 elif test "x${with_storage}" == "xdouble"
 then
-	AC_DEFINE([STORAGE_TYPE], [64], [Using half as storage])
+	AC_DEFINE([STORAGE_BITS], [64], [Using half as storage])
 elif test "x${with_storage}" != "x"
 then
 	AC_MSG_ERROR([Not suppported type of storage: x${with_storage}])

--- a/src/types.h
+++ b/src/types.h
@@ -9,17 +9,17 @@
   #endif
   typedef struct {real_t x,y,z;} vector_t;
 
-  #ifndef STORAGE_TYPE
+  #ifndef STORAGE_BITS
     #ifdef CALC_DOUBLE_PRECISION
       typedef double storage_t;
     #else
       typedef float storage_t;
     #endif
-  #elif STORAGE_TYPE == 16
+  #elif STORAGE_BITS == 16
       typedef short int storage_t;
-  #elif STORAGE_TYPE == 32
+  #elif STORAGE_BITS == 32
       typedef int storage_t;
-  #elif STORAGE_TYPE == 64
+  #elif STORAGE_BITS == 64
       typedef long long int storage_t;
   #endif
   typedef unsigned short int cut_t;


### PR DESCRIPTION
This fixes a bug while compiling with RInside.