### PR TITLE
VTK and HDF5 output additions + cpu output fix

### DIFF
--- a/src/Handlers/cbHDF5.cpp
+++ b/src/Handlers/cbHDF5.cpp
@@ -4,37 +4,37 @@ std::string cbHDF5::xmlname = "HDF5";
 #include "../hdf5Lattice.h"
 
 int cbHDF5::Init () {
-	options = 0;
-	Callback::Init();
+		options = 0;
+		Callback::Init();
 #ifdef WITH_HDF5
 		pugi::xml_attribute attr = node.attribute("name");
 		nm = "HDF5";
 		if (attr) nm = attr.value();
 		attr = node.attribute("what");
 		if (attr) {
-		        s.add_from_string(attr.value(),',');
-                } else {
-                        s.add_from_string("all",',');
-                }
+			s.add_from_string(attr.value(),',');
+		} else {
+			s.add_from_string("all",',');
+		}
 
-                bool deflate = true;
+		bool deflate = true;
 		attr = node.attribute("compress");
 		if (attr) deflate = attr.as_bool();
 		if (deflate) options = options | HDF5_DEFLATE;
 		bool write_xdmf = true;
 		attr = node.attribute("write_xdmf");
 		if (attr) write_xdmf = attr.as_bool();
-                if (write_xdmf) options = options | HDF5_WRITE_XDMF;
+		if (write_xdmf) options = options | HDF5_WRITE_XDMF;
 		bool point_data = false;
 		attr = node.attribute("point_data");
 		if (attr) point_data = attr.as_bool();
-                if (point_data) options = options | HDF5_WRITE_POINT;
+		if (point_data) options = options | HDF5_WRITE_POINT;
 		attr = node.attribute("chunk");
 		bool calc_double;
 #ifdef CALC_DOUBLE_PRECISION
-                        calc_double = true;
+		calc_double = true;
 #else
-                        calc_double = false;
+		calc_double = false;
 #endif
 		bool write_double;
 		write_double = calc_double;
@@ -43,7 +43,7 @@ int cbHDF5::Init () {
 			if (strcmp(attr.value(),"double") == 0) {
 				write_double = true;
 			} else if (strcmp(attr.value(),"float") == 0) {
-	                        write_double = false;
+				write_double = false;
 			} else {
 				ERROR("write_double attribute should be double of false\n", attr.value());
 			}
@@ -55,23 +55,64 @@ int cbHDF5::Init () {
 				notice("Writing a different type then type you calculate");
 			}
 		}		
-                if (write_double) options = options | HDF5_WRITE_DOUBLE;
+		if (write_double) options = options | HDF5_WRITE_DOUBLE;
+
+		reg = solver->mpi.totalregion;
+		attr = node.attribute("dx");
+		if (attr) { reg.dx = solver->units.alt(attr.value()); }
+		if (reg.dx < 0) {
+			reg.dx = reg.nx + reg.dx;
+			reg.nx = reg.nx - reg.dx;
+		}
+		attr = node.attribute("dy");
+		if (attr) { reg.dy = solver->units.alt(attr.value()); }
+		if (reg.dy < 0) {
+			reg.dy = reg.ny + reg.dy;
+			reg.ny = reg.ny - reg.dy;
+		}
+		attr = node.attribute("dz");
+		if (attr) { reg.dz = solver->units.alt(attr.value()); }
+		if (reg.dz < 0) {
+			reg.dz = reg.nz + reg.dz;
+			reg.nz = reg.nz - reg.dz;
+		}
+		attr = node.attribute("nx");
+		if (attr) { reg.nx = solver->units.alt(attr.value()); }
+		if (reg.nx < 0) { reg.nx = solver->mpi.totalregion.nx - reg.dx + reg.nx; }
+		attr = node.attribute("ny");
+		if (attr) { reg.ny = solver->units.alt(attr.value()); }
+		if (reg.ny < 0) { reg.ny = solver->mpi.totalregion.ny - reg.dy + reg.nz; }
+		attr = node.attribute("nz");
+		if (attr) { reg.nz = solver->units.alt(attr.value()); }
+		if (reg.nz < 0) { reg.nz = solver->mpi.totalregion.nz - reg.dz + reg.nz; }
+		reg = reg.intersect(solver->mpi.totalregion);
+		debug1("HDF5 \"%s\" with output region: %dx%dx%d + %d,%d,%d from total region %dx%dx%d + %d,%d,%d", nm.c_str(), 
+		reg.nx,reg.ny,reg.nz,reg.dx,reg.dy,reg.dz,solver->mpi.totalregion.nx,solver->mpi.totalregion.ny,solver->mpi.totalregion.nz,solver->mpi.totalregion.dx,solver->mpi.totalregion.dy,solver->mpi.totalregion.dz);
+		if (reg.size() == 0) {
+			ERROR("HDF5 \"%s\" output has size 0", nm.c_str());
+			return -1;
+		}
+
+		lbRegion local_reg = reg.intersect(solver->lattice->region);
+
 		attr = node.attribute("chunk");
 		if (attr) {
 			ERROR("Supplying chunk size is not yet supported");
 			return -1;
-                } else { // Negotiate optimal chunk dimenstions
-                	unsigned long int dim[3];
-			dim[0] = solver->lattice->region.nz;
-			dim[1] = solver->lattice->region.ny;
-			dim[2] = solver->lattice->region.nx;
+		} else { // Negotiate optimal chunk dimentions
+			unsigned long int dim[3];
+			dim[0] = local_reg.nz;
+			dim[1] = local_reg.ny;
+			dim[2] = local_reg.nx;
 			for (int i = 0; i < 3; i++) {
 				unsigned long int GCD, minGCD, maxGCD;
 				GCD = dim[i];
 				for (int j = 0; j < 500; j++) { // This is just a safty limit of iterations
+					if (local_reg.size() == 0) GCD = solver->mpi.totalregion.size(); //Guarunteed to be greater than any single dimension
 					MPI_Allreduce(&GCD, &minGCD, 1, MPI_UNSIGNED_LONG, MPI_MIN, solver->mpi_comm);
+					if (local_reg.size() == 0) GCD = 0;
 					MPI_Allreduce(&GCD, &maxGCD, 1, MPI_UNSIGNED_LONG, MPI_MAX, solver->mpi_comm);
-					debug1("%d %d GCD: %ld (%ld-%ld)\n", i, j,	GCD, minGCD, maxGCD);
+					myprint(1,-1,"%d %d GCD: %ld (%ld-%ld)\n", i, j,	GCD, minGCD, maxGCD);
 					if (maxGCD == minGCD) break;
 					GCD = GCD % minGCD;
 					if (GCD == 0) GCD = minGCD;
@@ -80,11 +121,11 @@ int cbHDF5::Init () {
 					ERROR("Parallel GCD did not work\n");
 					return -1;
 				}
-				chunkdim[i] = GCD;
+				chunkdim[i] = minGCD;
 			}
 			output("Negotiated HDF5 chunks: %ldx%ldx%ld[x3]\n", chunkdim[0], chunkdim[1], chunkdim[2]);
 		}                
-                return 0;
+		return 0;
 #else
 		ERROR("No hdf5 support at configure\n");
 		return -1;
@@ -95,7 +136,7 @@ int cbHDF5::Init () {
 int cbHDF5::DoIt () {
 #ifdef WITH_HDF5
 		Callback::DoIt();
-		return hdf5WriteLattice(nm.c_str(), solver, &s, chunkdim, options);
+		return hdf5WriteLattice(nm.c_str(), solver, &s, chunkdim, options, reg);
 #else
 		return -1;
 #endif

--- a/src/Handlers/cbHDF5.h
+++ b/src/Handlers/cbHDF5.h
@@ -7,6 +7,7 @@
 #include "Callback.h"
 
 class  cbHDF5  : public  Callback  {
+	lbRegion reg;
 	std::string nm;
 	name_set s;
 	unsigned long int chunkdim[3];

--- a/src/Handlers/cbVTK.cpp
+++ b/src/Handlers/cbVTK.cpp
@@ -9,17 +9,58 @@ int cbVTK::Init () {
 		if (attr) nm = attr.value();
 		attr = node.attribute("what");
 		if (attr) {
-		        s.add_from_string(attr.value(),',');
-                } else {
-                        s.add_from_string("all",',');
-                }
+			s.add_from_string(attr.value(),',');
+		} else {
+			s.add_from_string("all",',');
+		}
+
+		reg = solver->mpi.totalregion;
+	
+		attr = node.attribute("dx");
+		if (attr) { reg.dx = solver->units.alt(attr.value()); }
+		if (reg.dx < 0) {
+			reg.dx = reg.nx + reg.dx;
+			reg.nx = reg.nx - reg.dx;
+		}
+		attr = node.attribute("dy");
+		if (attr) { reg.dy = solver->units.alt(attr.value()); }
+		if (reg.dy < 0) {
+			reg.dy = reg.ny + reg.dy;
+			reg.ny = reg.ny - reg.dy;
+		}
+		attr = node.attribute("dz");
+		if (attr) { reg.dz = solver->units.alt(attr.value()); }
+		if (reg.dz < 0) {
+			reg.dz = reg.nz + reg.dz;
+			reg.nz = reg.nz - reg.dz;
+		}
+
+		attr = node.attribute("nx");
+		if (attr) { reg.nx = solver->units.alt(attr.value()); }
+		if (reg.nx < 0) { reg.nx = solver->mpi.totalregion.nx - reg.dx + reg.nx; }
+		attr = node.attribute("ny");
+		if (attr) { reg.ny = solver->units.alt(attr.value()); }
+		if (reg.ny < 0) { reg.ny = solver->mpi.totalregion.ny - reg.dy + reg.nz; }
+		attr = node.attribute("nz");
+		if (attr) { reg.nz = solver->units.alt(attr.value()); }
+		if (reg.nz < 0) { reg.nz = solver->mpi.totalregion.nz - reg.dz + reg.nz; }
+
+		reg = reg.intersect(solver->mpi.totalregion);
+
+		debug1("VTK \"%s\" with output region: %dx%dx%d + %d,%d,%d from total region %dx%dx%d + %d,%d,%d", nm.c_str(), 
+		reg.nx,reg.ny,reg.nz,reg.dx,reg.dy,reg.dz,solver->mpi.totalregion.nx,solver->mpi.totalregion.ny,solver->mpi.totalregion.nz,solver->mpi.totalregion.dx,solver->mpi.totalregion.dy,solver->mpi.totalregion.dz);
+		if (reg.size() == 0) {
+			ERROR("VTK \"%s\" output has size 0", nm.c_str());
+			return -1;
+		}
+
 		return 0;
 	}
 
 
 int cbVTK::DoIt () {
 		Callback::DoIt();
-		return solver->writeVTK(nm.c_str(), &s);
+		return solver->writeVTK(nm.c_str(), &s, reg);
 	};
 
 

--- a/src/Handlers/cbVTK.h
+++ b/src/Handlers/cbVTK.h
@@ -7,6 +7,7 @@
 #include "Callback.h"
 
 class  cbVTK  : public  Callback  {
+	lbRegion reg;
 	std::string nm;
 	name_set s;
 	public:

--- a/src/Solver.cpp.Rt
+++ b/src/Solver.cpp.Rt
@@ -215,11 +215,11 @@ void MainFree( Solver *d);
 	\param nm Appendix added to the name of the vti file written
 	\param s Set of fields/quantities/geometry features to write
 */
-	int Solver::writeVTK(const char * nm, name_set * s) {
+	int Solver::writeVTK(const char * nm, name_set * s, lbRegion region) {
 		print("writing vtk");
 		char filename[2*STRING_LEN];
 		outIterFile(nm, ".vti", filename);
-		int ret = vtkWriteLattice(filename, lattice, units, s);
+		int ret = vtkWriteLattice(filename, lattice, units, s, region);
 		return ret;
 	}
 

--- a/src/Solver.h.Rt
+++ b/src/Solver.h.Rt
@@ -134,7 +134,7 @@ class Solver {
 	void Gauge();
 	int initLog(const char * filename);
 	int writeLog(const char * filename);
-	int writeVTK(const char * nm, name_set * s);
+	int writeVTK(const char * nm, name_set * s, lbRegion region);
 	int writeTXT(const char * nm, name_set * s, int type);
 	int writeBIN(const char * nm);
 	int setSize(int,int,int,int);

--- a/src/cross.h
+++ b/src/cross.h
@@ -244,13 +244,15 @@
                                       OMP_PARALLEL_FOR \
                                        for (int x__ = 0; x__ < b__.x; x__++) { CpuBlock.x = x__; \
                                         for (CpuBlock.y = 0; CpuBlock.y < b__.y; CpuBlock.y++) \
-                                         a__ d__; \
+                                         for (CpuBlock.z = 0; CpuBlock.z < b__.z; CpuBlock.z++) \
+                                          a__ d__; \
                                        }
     #else
       #define CudaKernelRun(a__,b__,c__,d__) \
                                       for (CpuBlock.y = 0; CpuBlock.y < b__.y; CpuBlock.y++) \
                                        for (CpuBlock.x = 0; CpuBlock.x < b__.x; CpuBlock.x++) \
-                                        a__ d__;
+                                        for (CpuBlock.z = 0; CpuBlock.z < b__.z; CpuBlock.z++) \
+                                         a__ d__;
     #endif
 
     #define CudaKernelRunNoWait(a__,b__,c__,d__,e__) CudaKernelRun(a__,b__,c__,d__);

--- a/src/hdf5Lattice.cpp.Rt
+++ b/src/hdf5Lattice.cpp.Rt
@@ -27,7 +27,7 @@ std::string NameXPath(const pugi::xml_node& node) {
 	return path;
 }
 
-int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned long int * chunkdim_, unsigned int options)
+int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned long int * chunkdim_, unsigned int options, lbRegion total_output_reg)
 {
 #ifdef WITH_HDF5
 	Glue glue;
@@ -43,7 +43,16 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 	basename = filename;
 	for (char * n = filename; n[0] != '\0'; n++) {
 		if (n[0] == '/') basename = n+1;
-	}		
+	}
+
+	size_t size;
+	lbRegion local_reg = lattice->region;
+	lbRegion reg = local_reg.intersect(total_output_reg);
+	size = reg.size();
+
+	myprint(1,-1,"Writing region %dx%dx%d + %d,%d,%d (size %d) from %dx%dx%d + %d,%d,%d", 
+		reg.nx,reg.ny,reg.nz,reg.dx,reg.dy,reg.dz, size,
+		local_reg.nx,local_reg.ny,local_reg.nz,local_reg.dx,local_reg.dy,local_reg.dz);
 
 	pugi::xml_document xdmf_doc;
 	pugi::xml_node xdmf_main = xdmf_doc.append_child("Xdmf");
@@ -68,7 +77,7 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 	{
 		double shift = 0.0;
 		if (options & HDF5_WRITE_POINT) shift = 0.5;
-		xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(" ") << (lattice->px + shift)/unit << (lattice->py + shift)/unit << (lattice->pz + 0.5)/unit);
+		xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(" ") << (lattice->pz + shift + total_output_reg.dz)/unit << (lattice->py + shift + total_output_reg.dy)/unit << (lattice->px + shift + total_output_reg.dx)/unit);
 	}
 	xdmf_dataitem = xdmf_geometry.append_child("DataItem");
 	xdmf_dataitem.append_attribute("DataType") = "Float";
@@ -77,22 +86,17 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 	xdmf_dataitem.append_attribute("Precision") = 8;
 	xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(" ") << 1/unit << 1/unit << 1/unit);
 	
-	size_t size;
-	lbRegion reg = lattice->region;
-	lbRegion totalreg = lattice->mpi.totalregion;
-	size = reg.size();
-
-    hid_t       file_id, dset_id;         /* file and dataset identifiers */
-    hsize_t     totaldim[4];                 /* dataset dimensions */
-    hsize_t     dim[4];            /* local dimensions */
-    hsize_t     chunkdim[4];            /* local dimensions */
-    hsize_t     totalpointdim[4];            /* point dimensions */
-    hsize_t	offset[4];
-    int         *data;                    /* pointer to data buffer to write */
-    hsize_t	ones[4];	         
-    int         i;
-    herr_t	status;
-    hid_t plist_id;
+	hid_t       file_id, dset_id;         /* file and dataset identifiers */
+	hsize_t     totaldim[4];                 /* dataset dimensions */
+	hsize_t     dim[4];            /* local dimensions */
+	hsize_t     chunkdim[4];            /* local dimensions */
+	hsize_t     totalpointdim[4];            /* point dimensions */
+	hsize_t	offset[4];
+	int         *data;                    /* pointer to data buffer to write */
+	hsize_t	ones[4];	         
+	int         i;
+	herr_t	status;
+	hid_t plist_id;
 
 
 
@@ -101,37 +105,37 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 	ones[2] = 1;
 	ones[3] = 1;
 
-    totaldim[0] = totalreg.nz;
-    totaldim[1] = totalreg.ny;
-    totaldim[2] = totalreg.nx;
-    totaldim[3] = 3;
-    dim[0] = reg.nz;   
-    dim[1] = reg.ny;   
-    dim[2] = reg.nx;
-    dim[3] = 3;
-    offset[0] = reg.dz;
-    offset[1] = reg.dy;
-    offset[2] = reg.dx;
-    offset[3] = 0;
+	totaldim[0] = total_output_reg.nz;
+	totaldim[1] = total_output_reg.ny;
+	totaldim[2] = total_output_reg.nx;
+	totaldim[3] = 3;
+	dim[0] = reg.nz;   
+	dim[1] = reg.ny;   
+	dim[2] = reg.nx;
+	dim[3] = 3;
+	offset[0] = reg.dz - total_output_reg.dz;
+	offset[1] = reg.dy - total_output_reg.dy;
+	offset[2] = reg.dx - total_output_reg.dx;
+	offset[3] = 0;
 
-    totalpointdim[0] = totalreg.nz+1;
-    totalpointdim[1] = totalreg.ny+1;
-    totalpointdim[2] = totalreg.nx+1;
+	totalpointdim[0] = total_output_reg.nz+1;
+	totalpointdim[1] = total_output_reg.ny+1;
+	totalpointdim[2] = total_output_reg.nx+1;
 
 
-    MPI_Comm comm  = MPMD.local;
-    MPI_Info info  = MPI_INFO_NULL;
+	MPI_Comm comm  = MPMD.local;
+	MPI_Info info  = MPI_INFO_NULL;
 
 	if (chunkdim_ != NULL) {
-	    chunkdim[0] = chunkdim_[0];
-	    chunkdim[1] = chunkdim_[1];
-	    chunkdim[2] = chunkdim_[2];
-	    chunkdim[3] = 3;
+		chunkdim[0] = chunkdim_[0];
+		chunkdim[1] = chunkdim_[1];
+		chunkdim[2] = chunkdim_[2];
+		chunkdim[3] = 3;
 	} else {
-	    chunkdim[0] = 1;
-	    chunkdim[1] = 1;
-	    chunkdim[2] = totaldim[3];
-	    chunkdim[3] = totaldim[3];
+		chunkdim[0] = 1;
+		chunkdim[1] = 1;
+		chunkdim[2] = totaldim[3];
+		chunkdim[3] = totaldim[3];
 	}					
 
 	pugi::xml_node xdmf_topology = xdmf_grid.append_child("Topology");
@@ -144,7 +148,7 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 
 	pugi::xml_node xdmf_attribute;
 
-	debug2("hdf5 file: %s\n   domain: %lldx%lldx%lld chunks: %lldx%lldx%lld local: %lldx%lldx%lld+%lld,%lld,%lld\n",
+	myprint(2,-1,"hdf5 file: %s\n   domain: %lldx%lldx%lld chunks: %lldx%lldx%lld local: %lldx%lldx%lld+%lld,%lld,%lld\n",
 		filename,
 		totaldim[0], totaldim[1], totaldim[2],
 		chunkdim[0], chunkdim[1], chunkdim[2],
@@ -152,9 +156,90 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 		offset[0], offset[1], offset[2]);
 
 	plist_id = H5Pcreate(H5P_FILE_ACCESS);
-		H5Pset_fapl_mpio(plist_id, comm, info);
-	    	file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
-    	H5Pclose(plist_id);
+	H5Pset_fapl_mpio(plist_id, comm, info);
+	file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
+	H5Pclose(plist_id);
+	
+
+	flag_t * NodeType = new flag_t[size];
+	lattice->GetFlags(reg, NodeType);
+	<?R
+	i = !duplicated(NodeTypes$group)
+	for (n in rows(NodeTypes[i,])) {
+	?>
+	{
+		hid_t       filespace, memspace;
+		char * fieldname = "<?%s n$group ?>";
+		hid_t input_type = H5T_NATIVE_UCHAR;
+		hid_t output_type = H5T_NATIVE_UCHAR;
+		int output_precision = 1;
+		int rank = 3;
+		filespace = H5Screate_simple(rank, totaldim, NULL); 
+		memspace  = H5Screate_simple(rank, dim, NULL); 
+		plist_id = H5Pcreate(H5P_DATASET_CREATE);
+
+		
+		status = H5Pset_chunk (plist_id, rank, chunkdim);
+		if (status < 0) return H5Eprint1(stderr);
+		if (options & HDF5_DEFLATE) status = H5Pset_deflate (plist_id, 6);
+		if (status < 0) return H5Eprint1(stderr);
+	   	dset_id = H5Dcreate2(file_id, fieldname, output_type, filespace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
+		H5Pclose(plist_id);
+		if (size == 0) {
+			status = H5Sselect_none(filespace);
+		} else {
+	  		status = H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset, ones, ones, dim);
+		}
+	   	if (status < 0) return H5Eprint1(stderr);
+
+		unsigned char * tmp = new unsigned char[size];
+		for (size_t i=0;i<size;i++) {
+			tmp[i] = (NodeType[i] & NODE_<?%s n$group ?>) >> <?%d n$shift ?>;
+		}
+
+		myprint(0,-1,"filespace: %lld memsize: %lld\n", H5Sget_select_npoints(filespace), H5Sget_select_npoints(memspace));
+		plist_id = H5Pcreate(H5P_DATASET_XFER);
+		H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
+		status = H5Dwrite(dset_id, input_type, memspace, filespace, plist_id, tmp);
+		
+		H5Pclose(plist_id);
+		H5Sclose(filespace);
+		H5Sclose(memspace);
+		H5Dclose(dset_id);
+
+		delete[] tmp;
+		xdmf_attribute = xdmf_grid.append_child("Attribute");
+		if (options & HDF5_WRITE_POINT) {
+			xdmf_attribute.append_attribute("Center") = "Node";
+		} else {
+			xdmf_attribute.append_attribute("Center") = "Cell";
+		}
+		xdmf_attribute.append_attribute("Name") = fieldname;
+		xdmf_dataitem = xdmf_attribute.append_child("DataItem");
+		xdmf_dataitem.append_attribute("DataType") = "Float";
+		xdmf_dataitem.append_attribute("Dimensions") = glue(" ") << std::make_pair(totaldim, rank);
+		xdmf_dataitem.append_attribute("Format") = "HDF";
+		xdmf_dataitem.append_attribute("Precision") = output_precision;
+		xdmf_dataitem.append_child(pugi::node_pcdata).set_value(glue(":") << basename << fieldname);
+		std::string xdmf_dataitem_path = NameXPath(xdmf_dataitem);
+		if (options & HDF5_WRITE_LBM) {
+			xdmf_attribute = xdmf_grid.append_child("Attribute");
+			if (options & HDF5_WRITE_POINT) {
+				xdmf_attribute.append_attribute("Center") = "Node";
+			} else {
+				xdmf_attribute.append_attribute("Center") = "Cell";
+			}
+			xdmf_attribute.append_attribute("Name") = glue("_") << fieldname << "LB";
+			xdmf_dataitem = xdmf_attribute.append_child("DataItem");
+			xdmf_dataitem.append_attribute("ItemType") = "Function";
+			xdmf_dataitem.append_attribute("Function") = glue(" ") << unit << "*" << "$0";
+			xdmf_dataitem.append_attribute("Dimensions") = glue(" ") << std::make_pair(totaldim, rank);
+			xdmf_dataitem = xdmf_dataitem.append_child("DataItem");
+			xdmf_dataitem.append_attribute("Reference") = xdmf_dataitem_path.c_str();
+		}
+	}
+	<?R }; ?>
+	delete[] NodeType;
 
 	<?R for (q in rows(Quantities)) { ifdef(q$adjoint); ?>
 	{
@@ -186,20 +271,24 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 			if (status < 0) return H5Eprint1(stderr);
 			if (options & HDF5_DEFLATE) status = H5Pset_deflate (plist_id, 6);
 			if (status < 0) return H5Eprint1(stderr);
-	                    	dset_id = H5Dcreate2(file_id, fieldname, output_type, filespace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
+			dset_id = H5Dcreate2(file_id, fieldname, output_type, filespace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
 			H5Pclose(plist_id);
 
-                    	status = H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset, ones, ones, dim);
-                    	if (status < 0) return H5Eprint1(stderr);
+			if (size == 0) {
+				status = H5Sselect_none(filespace);
+			} else {
+				status = H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset, ones, ones, dim);
+			}
+			if (status < 0) return H5Eprint1(stderr);
 
 			unit = units->alt("<?%s q$unit ?>");
-	                <?%s q$type ?>* tmp = new <?%s q$type ?>[size];
-                        lattice->Get<?%s q$name ?>(reg, tmp, 1/unit);
+			<?%s q$type ?>* tmp = new <?%s q$type ?>[size];
+			lattice->Get<?%s q$name ?>(reg, tmp, 1/unit);
 
-			debug0("filespace: %lld memsize: %lld\n", H5Sget_select_npoints(filespace), H5Sget_select_npoints(memspace));
+			myprint(0,-1,"filespace: %lld memsize: %lld\n", H5Sget_select_npoints(filespace), H5Sget_select_npoints(memspace));
 			plist_id = H5Pcreate(H5P_DATASET_XFER);
-				H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
-				status = H5Dwrite(dset_id, input_type, memspace, filespace, plist_id, tmp);
+			H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
+			status = H5Dwrite(dset_id, input_type, memspace, filespace, plist_id, tmp);
 			
 			H5Pclose(plist_id);
 			H5Sclose(filespace);
@@ -247,8 +336,8 @@ int hdf5WriteLattice(const char * nm, Solver * solver, name_set * what, unsigned
 
 	if (options & HDF5_WRITE_XDMF) {
 		if (lattice->mpi.rank == 0) {
-		    solver->outIterCollectiveFile(nm, ".xmf", filename);
-		    xdmf_doc.save_file(filename);
+			solver->outIterCollectiveFile(nm, ".xmf", filename);
+			xdmf_doc.save_file(filename);
 		}
 	}
 

--- a/src/hdf5Lattice.h
+++ b/src/hdf5Lattice.h
@@ -11,7 +11,7 @@
 	#define HDF5_WRITE_LBM 0x08
 	#define HDF5_WRITE_POINT 0x10
 	
-	int hdf5WriteLattice(const char * filename, Solver * solver, name_set * s, unsigned long int* chunkdim_, unsigned int options);
+	int hdf5WriteLattice(const char * filename, Solver * solver, name_set * s, unsigned long int* chunkdim_, unsigned int options, lbRegion region);
 
 #endif
 #define HDF5LATTICE_H 1

--- a/src/vtkLattice.cpp.Rt
+++ b/src/vtkLattice.cpp.Rt
@@ -14,15 +14,20 @@
 
 #ifdef CROSS_NOFORK
 
-int vtkWriteLattice(char * filename, Lattice * lattice, UnitEnv units, name_set * what)
+int vtkWriteLattice(char * filename, Lattice * lattice, UnitEnv units, name_set * what, lbRegion total_output_reg)
 {
 	size_t size;
-	lbRegion reg = lattice->region;
+	lbRegion local_reg = lattice->region;
+	lbRegion reg = local_reg.intersect(total_output_reg);
 	size = reg.size();
+	myprint(1,-1,"Writing region %dx%dx%d + %d,%d,%d (size %d) from %dx%dx%d + %d,%d,%d", 
+		reg.nx,reg.ny,reg.nz,reg.dx,reg.dy,reg.dz, size,
+		local_reg.nx,local_reg.ny,local_reg.nz,local_reg.dx,local_reg.dy,local_reg.dz);
+
 	vtkFileOut vtkFile(MPMD.local);
 	if (vtkFile.Open(filename)) {return -1;}
 	double spacing = 1/units.alt("m");	
-	vtkFile.Init(lattice->mpi.totalregion, reg, "Scalars=\"rho\" Vectors=\"velocity\"", spacing, lattice->px*spacing, lattice->py*spacing, lattice->pz*spacing);
+	vtkFile.Init(total_output_reg, reg, "Scalars=\"rho\" Vectors=\"velocity\"", spacing, lattice->px*spacing, lattice->py*spacing, lattice->pz*spacing);
 
 	{	flag_t * NodeType = new flag_t[size];
 		lattice->GetFlags(reg, NodeType);
@@ -65,11 +70,15 @@ int vtkWriteLattice(char * filename, Lattice * lattice, UnitEnv units, name_set 
 
 #else
 
-int vtkWriteLattice(char * filename, Lattice * lattice, UnitEnv units, name_set * what)
+int vtkWriteLattice(char * filename, Lattice * lattice, UnitEnv units, name_set * what, lbRegion total_output_reg)
 {
-	int size;
-	lbRegion reg = lattice->region;
+	size_t size;
+	lbRegion local_reg = lattice->region;
+	lbRegion reg = local_reg.intersect(total_output_reg);
 	size = reg.size();
+	myprint(1,-1,"Writing region %dx%dx%d + %d,%d,%d (size %d) from %dx%dx%d + %d,%d,%d", 
+		reg.nx,reg.ny,reg.nz,reg.dx,reg.dy,reg.dz, size,
+		local_reg.nx,local_reg.ny,local_reg.nz,local_reg.dx,local_reg.dy,local_reg.dz);
 
 
 	flag_t * NodeType = new flag_t[size];
@@ -89,7 +98,7 @@ int vtkWriteLattice(char * filename, Lattice * lattice, UnitEnv units, name_set 
 		vtkFileOut vtkFile(MPMD.local);
 		if (vtkFile.Open(filename)) {return -1;}
 		double spacing = 1/units.alt("m");	
-		vtkFile.Init(lattice->mpi.totalregion, reg, "Scalars=\"rho\" Vectors=\"velocity\"", spacing);
+		vtkFile.Init(total_output_reg, reg, "Scalars=\"rho\" Vectors=\"velocity\"", spacing);
 
 		if (what->in("flag")) {
 			vtkFile.WriteField("flag",NodeType);

--- a/src/vtkLattice.h
+++ b/src/vtkLattice.h
@@ -7,7 +7,7 @@
 	#include "unit.h"
 	#include "utils.h"
 
-	int vtkWriteLattice(char * filename, Lattice * lattice, UnitEnv, name_set * s);
+	int vtkWriteLattice(char * filename, Lattice * lattice, UnitEnv, name_set * s, lbRegion region);
 	int binWriteLattice(char * filename, Lattice * lattice, UnitEnv units);
 	int txtWriteLattice(char * filename, Lattice * lattice, UnitEnv, name_set * s, int type);
 	void screenDumpLattice(Lattice * lattice);


### PR DESCRIPTION
Addresses #186. Region definition works similarly to Geometry definition, negative dx and nx work backwards from domain end.
Also adds nodetypes to HDF5 outputs.
Fixes outputs for cpu only builds where the z axis was not being looped over.
