### PR TITLE
Don't exec CudaKernelRun when block/region has a size of 0

### DIFF
--- a/src/Lattice.cu.Rt
+++ b/src/Lattice.cu.Rt
@@ -1219,6 +1219,7 @@ void Lattice::Get<?%s q$name ?>(lbRegion over, <?%s q$type ?> * tab, real_t scal
         container->CopyToConst();
 
 	lbRegion inter = region.intersect(over);
+	if (inter.size()==0) return;
 	<?%s q$type ?> * buf=NULL;
 	CudaMalloc((void**)&buf, inter.sizeL()*sizeof(<?%s q$type ?>));
         {	lbRegion small = inter;


### PR DESCRIPTION
When outputting small regions over multiple MPI+CUDA processes, CudeKernelRun was sometimes called with a block size of 0 raising an "invalid configuration argument" error. This change just makes Get<?%s q$name ?> return before making kernel calls and memory allocations if this is the case.
Should only impact MPI+CUDA builds, CPU-only already handled blocks with 0 size in the cross.h for loop.