### PR TITLE
Switching to `steady_clock` for walltime

### DIFF
--- a/src/Global.cpp.Rt
+++ b/src/Global.cpp.Rt
@@ -25,7 +25,19 @@
 
 MPMDHelper MPMD;
 
-std::clock_t global_start;
+time_point_t global_start;
+
+void start_walltime() {
+    #ifdef USE_STEADY_CLOCK
+            global_start = std::chrono::steady_clock::now();
+            output("Using std::chrono::steady_clock::now() for walltime\n");
+    #else
+            global_start = std::clock();
+            output("Using std::clock() for walltime\n");
+    #endif
+}
+
+
 int D_MPI_RANK;
 int D_TERMINAL;
 /*

--- a/src/Global.h.Rt
+++ b/src/Global.h.Rt
@@ -85,12 +85,28 @@ for (m in Margin) { ?>
 #endif
 */
 #ifndef DEBUG_H   
-    #include <ctime>
-    extern std::clock_t global_start;
+  #ifdef USE_STEADY_CLOCK
+	#include <chrono>
+	typedef std::chrono::time_point<std::chrono::steady_clock> time_point_t;
+  #else
+	#include <ctime>
+	typedef std::clock_t time_point_t;
+  #endif
+
+    extern time_point_t global_start;
 
     inline double get_walltime() {
-       return (std::clock() - global_start) / (double)CLOCKS_PER_SEC;
+	#ifdef USE_STEADY_CLOCK
+		time_point_t now = std::chrono::steady_clock::now();
+		std::chrono::duration<double, std::milli> ms = now - global_start;
+		return ms.count() / 1000.0;
+	#else
+		time_point_t now = std::clock();
+		return (now - global_start) / (double)CLOCKS_PER_SEC;
+	#endif
     }
+
+    void start_walltime();
 
     extern int D_MPI_RANK;
     extern int D_TERMINAL;

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -68,4 +68,7 @@
 /* Build-in python support */
 #undef EMBEDED_PYTHON
 
+/* If to use the C++11 chrono */
+#undef USE_STEADY_CLOCK
+
 #endif

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -777,11 +777,14 @@ then
 fi
 
 
-if test "x${enable_cpp11}" == "xyes"
+if test "x${enable_cpp11}" @= "xno"
 then
 	CPPFLAGS="${CPPFLAGS} -std=c++11"
 	NVFLAGS="${NVFLAGS} -std=c++11"
 fi
+
+AC_CHECK_HEADERS([chrono],[],[AC_MSG_ERROR([chrono header isn't working])])
+AC_DEFINE([USE_STEADY_CLOCK], [1], [Using chrono's steady_clock])
 
 
 if test "x${CONF_CPPFLAGS}" == "x"

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -777,14 +777,13 @@ then
 fi
 
 
-if test "x${enable_cpp11}" @= "xno"
+if test "x${enable_cpp11}" != "xno"
 then
 	CPPFLAGS="${CPPFLAGS} -std=c++11"
 	NVFLAGS="${NVFLAGS} -std=c++11"
 fi
 
-AC_CHECK_HEADERS([chrono],[],[AC_MSG_ERROR([chrono header isn't working])])
-AC_DEFINE([USE_STEADY_CLOCK], [1], [Using chrono's steady_clock])
+AC_CHECK_HEADERS([chrono],[AC_DEFINE([USE_STEADY_CLOCK], [1], [Using chrono's steady_clock])],[])
 
 
 if test "x${CONF_CPPFLAGS}" == "x"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -191,7 +191,7 @@ int main ( int argc, char * argv[] )
 	InitPrint(DEBUG_LEVEL, 6, 8);
 	MPI_Barrier(MPMD.local);
 
-	global_start = std::clock();
+	start_walltime();
 	if (solver->mpi_rank == 0) {
 		NOTICE("-------------------------------------------------------------------------\n");
 		NOTICE("-  CLB version: %25s                               -\n",VERSION);
@@ -419,7 +419,7 @@ int main ( int argc, char * argv[] )
 	CudaEventDestroy( stop );
 
 	if (solver->mpi_rank == 0) {
-		double duration = (std::clock() - global_start) / (double)CLOCKS_PER_SEC;
+		double duration = get_walltime();
 		output("Total duration: %lf s = %lf min = %lf h\n", duration, duration / 60, duration /60/60);
 	}
 	delete solver;


### PR DESCRIPTION
This PR switches the `std::chrono::steady_clock::now()` for walltime measurement in output and in log `csv` files. The previous use of `::clock()` was really CPU time, and was giving misleading results.