### PR TITLE
Field access checks

### DIFF
--- a/models/electrokinetic/d2q9_poison_boltzmann/Dynamics.R
+++ b/models/electrokinetic/d2q9_poison_boltzmann/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 
 AddDensity( name="g[0]", dx= 0, dy= 0, group="g")
 AddDensity( name="g[1]", dx= 1, dy= 0, group="g")

--- a/models/experimental/d3q27_csf/Dynamics.R
+++ b/models/experimental/d3q27_csf/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 
 U = expand.grid(-1:1,-1:1,-1:1)
 

--- a/models/flow/auto/Dynamics.R
+++ b/models/flow/auto/Dynamics.R
@@ -57,8 +57,9 @@ AddNodeType(name="Body", group="BODY")
 for (f in fname) AddField(f,dx=0,dy=0,dz=0) # Make f accessible also in present node (not only streamed)
 
 if (Options$part) {
-	AddStage("BaseIteration", "Run", save=Fields$group %in% c("f","Force"), load = DensityAll$group %in% c("f","Force"))
-	AddStage("CalcF", save=Fields$group == "Force", load = DensityAll$group %in% c("f","Force"), particle=TRUE)
+	AddStage("BaseIteration", "Run", save=Fields$group %in% c("f"), load = DensityAll$group %in% c("f","Force"))
+	AddStage("BaseInit", "Init", save=Fields$group %in% c("f"))
+	AddStage("CalcF", save=Fields$group == "Force", load = DensityAll$group %in% c("f"), particle=TRUE)
 	AddAction("Iteration", c("BaseIteration", "CalcF"))
 	AddAction("Init", c("BaseInit", "CalcF"))
 }

--- a/models/flow/d2q9_par/Dynamics.R
+++ b/models/flow/d2q9_par/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 # Density - table of variables of LB Node to stream
 #  name - variable name to stream
 #  dx,dy,dz - direction of streaming

--- a/models/flow/d3q27_cumulant_part/Dynamics.R
+++ b/models/flow/d3q27_cumulant_part/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 x = c(0,1,-1);
 P = expand.grid(x=0:2,y=0:2,z=0:2)
 U = expand.grid(x,x,x)

--- a/models/heat/d3q27_tePSM_per/Dynamics.R
+++ b/models/heat/d3q27_tePSM_per/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 
 AddDensity( name="f[0]", dx= 0, dy= 0, dz= 0, group="f")
 AddDensity( name="f[1]", dx= 1, dy= 0, dz= 0, group="f")

--- a/models/multiphase/d2q9_ShanChen/Dynamics.R
+++ b/models/multiphase/d2q9_ShanChen/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 
 # Fluid Density Populations
 AddDensity( name="f[0]", dx= 0, dy= 0, group="f")

--- a/models/multiphase/d2q9_csf/Dynamics.R
+++ b/models/multiphase/d2q9_csf/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 # Density - table of variables of LB Node to stream
 #  name - variable name to stream
 #  dx,dy,dz - direction of streaming

--- a/models/multiphase/d2q9_kuper/Dynamics.R
+++ b/models/multiphase/d2q9_kuper/Dynamics.R
@@ -13,7 +13,7 @@ AddField("phi",stencil2d=1);
 
 AddStage("BaseIteration", "Run", save=Fields$group == "f", load=DensityAll$group == "f")
 AddStage("CalcPhi", save="phi",load=DensityAll$group == "f")
-AddStage("BaseInit", "Init", save=Fields$group == "f", load=DensityAll$group == "f")
+AddStage("BaseInit", "Init", save=Fields$group == "f")
 
 AddAction("Iteration", c("BaseIteration","CalcPhi"))
 AddAction("Init", c("BaseInit","CalcPhi"))

--- a/models/multiphase/d2q9_pf/Dynamics.R
+++ b/models/multiphase/d2q9_pf/Dynamics.R
@@ -43,17 +43,16 @@ if (Options$fd) {
     AddField("phi"      ,stencil2d=1 );
 
     AddStage("BaseIteration", "Run", 
-             load=DensityAll$group == "h" | DensityAll$group == "f" | DensityAll$group == "BC",
-             save=Fields$group=="h" | Fields$group=="f"  
-         ) 
+        load=DensityAll$group == "h" | DensityAll$group == "f" | DensityAll$group == "BC",
+        save=Fields$group=="h" | Fields$group=="f" | Fields$group == "BC"
+    ) 
     AddStage("CalcPhi", 
-             save=Fields$name=="phi" ,  
-             load=DensityAll$group == "h"
-         )
+        save=Fields$name=="phi" ,  
+        load=DensityAll$group == "h"
+    )
     AddStage("BaseInit", "Init",  
-	    load=DensityAll$group == "BC",
-        save=Fields$group=="h" | Fields$group == "f" 
- 
+	    load=FALSE,
+        save=Fields$group=="h" | Fields$group == "f" | Fields$group == "BC"
     )
     AddAction("Iteration", c("BaseIteration","CalcPhi"))
     AddAction("Init", c("BaseInit","CalcPhi"))

--- a/models/multiphase/d2q9_pf_pressureEvolution/Dynamics.R
+++ b/models/multiphase/d2q9_pf_pressureEvolution/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 # Density - table of variables of LB Node to stream
 #  name - variable name to stream
 #  dx,dy,dz - direction of streaming

--- a/models/multiphase/d2q9_pf_velocity/Dynamics.R
+++ b/models/multiphase/d2q9_pf_velocity/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 # 	Density - table of variables of LB Node to stream
 #	Pressure Evolution:
 AddDensity( name="g[0]", dx= 0, dy= 0, group="g")

--- a/models/multiphase/d2q9_scmp/Dynamics.R
+++ b/models/multiphase/d2q9_scmp/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 
 AddDensity( name="f[0]", dx= 0, dy= 0, group="f")
 AddDensity( name="f[1]", dx= 1, dy= 0, group="f")

--- a/models/multiphase/d3q19_kuper/Dynamics.R
+++ b/models/multiphase/d3q19_kuper/Dynamics.R
@@ -38,7 +38,7 @@ AddField("phi",stencil3d=1);
 
 AddStage("BaseIteration", "Run", save=Fields$group == "f", load=DensityAll$group == "f")
 AddStage("CalcPhi", save="phi",load=DensityAll$group == "f")
-AddStage("BaseInit", "Init", save=Fields$group == "f", load=DensityAll$group == "f")
+AddStage("BaseInit", "Init", save=Fields$group == "f")
 
 AddAction("Iteration", c("BaseIteration","CalcPhi"))
 AddAction("Init", c("BaseInit","CalcPhi"))

--- a/models/multiphase/d3q27_pf_velocity/Dynamics.R
+++ b/models/multiphase/d3q27_pf_velocity/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 # Density - table of variables of LB Node to stream
 #	Velocity-based Evolution d3q27:
 source("lattice.R")

--- a/models/multiphase/experimental/d2q9_pp_LBL/Dynamics.R
+++ b/models/multiphase/experimental/d2q9_pp_LBL/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 # Fluid Density Populations
 AddDensity( name="f[0]", dx= 0, dy= 0, group="f")
 AddDensity( name="f[1]", dx= 1, dy= 0, group="f")

--- a/models/multiphase/experimental/d2q9_pp_MCMP/Dynamics.R
+++ b/models/multiphase/experimental/d2q9_pp_MCMP/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 # Density - table of variables of LB Node to stream
 AddDensity( name="f[0]", dx= 0, dy= 0, group="f")
 AddDensity( name="f[1]", dx= 1, dy= 0, group="f")

--- a/models/reaction/d2q9_reaction_diffusion_system/Dynamics.R
+++ b/models/reaction/d2q9_reaction_diffusion_system/Dynamics.R
@@ -1,3 +1,10 @@
+# Setting permissive access policy.
+#  * This skips checks of fields being overwritten or read prematurely.
+#  * Otherwise the model compilation was failing.
+#  * This should be removed if the issue is fixed
+SetOptions(permissive.access=TRUE)  ### WARNING
+
+
 if (Options$AllenCahn) {
  	Qname = 'Allen-Cahn'
 	DREs <- ('PHI')

--- a/src/LatticeAccess.inc.cpp.Rt
+++ b/src/LatticeAccess.inc.cpp.Rt
@@ -204,8 +204,8 @@ CudaDeviceFunction flag_t LatticeContainer::getType(int x, int y, int z) const
 	)
  ))
  all_stages = lapply(all_stages, function(s) {
-  if (is.null(s$load.densities))  s$load.densities = DensityAll[,s$tag];
-  if (is.null(s$save.fields))  s$save.fields = Fields[,s$tag];
+  if (is.null(s$load.densities))  s$load.densities = DensityAll[,s$loadtag];
+  if (is.null(s$save.fields))  s$save.fields = Fields[,s$savetag];
   if (is.null(s$suffix))  s$suffix = paste("_",s$name,sep="")
   s
  })
@@ -223,6 +223,7 @@ CudaDeviceFunction flag_t LatticeContainer::getType(int x, int y, int z) const
 
   storage_to_real = function(val,f) storage_convert("storage_to_real",val,f)
   real_to_storage = function(val,f) storage_convert("real_to_storage",val,f)
+
 
 
 resolve.symmetries = function(D) {

--- a/src/SUMMARY.Rt
+++ b/src/SUMMARY.Rt
@@ -1,4 +1,5 @@
 <?R
+  plot.access=TRUE
   source("conf.R")
   save.image(file="SUMMARY.Rdata")
   options(width=4000)
@@ -45,4 +46,6 @@
     cat(sprintf("%-35s [%7s] | %1s | %s",s$name, s$unit, ifelse(s$adjoint, "X"," "), s$comment),"\n");
   }
   cat("---------------------------------------------------------------------------------------\n");
+  cat("\n");
+  cat("Field access plot: ", paste0("file://",getwd(),"/field_access.pdf"),"\n")
 ?>

--- a/src/conf.R
+++ b/src/conf.R
@@ -388,12 +388,9 @@ AddStage = function(name, main=name, load.densities=FALSE, save.fields=FALSE, re
 
 	sel = selection(DensityAll, load.densities)
 	DensityAll[, s$loadtag] <<- sel
-	loaded.fields = Fields$name %in% DensityAll$field[sel]
 	sel = selection(Fields, save.fields)
 	Fields[, s$savetag] <<- sel
 	sel = selection(Fields, read.fields)
-	sel[loaded.fields & is.na(sel)] = TRUE
-	if (! all(sel[loaded.fields])) stop("Not all fields loaded through densities are accessible in stage", s$name)
 	Fields[, s$readtag] <<- sel
 }
 

--- a/src/cuda.cu.Rt
+++ b/src/cuda.cu.Rt
@@ -25,6 +25,13 @@ if (exists('Extra_Dynamics_C_Header')) {
 #include "cross.h"
 #include "cross.hpp"
 #include "Global.h"
+#include "assert.h"
+
+CudaDeviceFunction real_t rise_nan() {
+	assert(false);
+	return NAN;
+}
+#define RISENAN rise_nan()
 
 
 class Node;


### PR DESCRIPTION
This PR introduces a new mechanism for setting and testing the access policy for fields in stages.

## Setting access
The `AddStage` has now three arguments:
- `load.densities=` specifies the `Densities` that are loaded at the beginning of the stage.
- `read.fields=` specifies the `Fields` that can be accessed in the Dynamics with `field(dx,dy,dz)` macros.
- `save.fields=` specifies the `Fields` that are saved at the end of the stage.

### Defaults
By default the actions/stages setup is:
```R
AddStage(main="Run", name="BaseIteration", load.densities=TRUE, read.fields=TRUE, save.fields=TRUE)
AddStage(main="Init", name="BaseInit", load.densities=FALSE, read.fields=FALSE, save.fields=TRUE)
AddAction(name="Iteration", stages=c("BaseIteration"))
AddAction(name="Init", stages=c("BaseInit"))
```
Moreover, the default `read.fields` is as allowing as possible. If not specified otherwise it is assumed that stage has read access to all fields that are available to it.

## Checks
The access policies are checked in each `Action` (series of `Stages`) assuming:
- You cannot read a field which wasn't written.
- You cannot overwrite already written fields
- You should write all fields by the end of the action
- `Init` action should not read anything from previous iteration.

### Exceptions
There are three mechanisms to circumvent checks:
- `non.mandatory=TRUE` in `AddField` signals that this field doesn't have to be written by the end of an action
- `can.overwrite=TRUE` in `AddStage` signals that a stage can overwrite fields
- `SetOptions(permissive.access=TRUE)` switches the test entirely and sets all fields to be readable in all stages. **This should be avoided**

## Modifications
Some adjustments were made to models to agree with these policies. All models were tested and `permissive.access=TRUE` was added to the ones failing from this change. These models should be fixed to accommodate these checks. Especially `d3q27_pf_velocity`, as per #437.

