### PR TITLE
Fixing error in test from d3q27_pf_velocity

### DIFF
--- a/models/multiphase/d3q27_pf_velocity/Dynamics.R
+++ b/models/multiphase/d3q27_pf_velocity/Dynamics.R
@@ -4,22 +4,25 @@
 #  * This should be removed if the issue is fixed
 SetOptions(permissive.access=TRUE)  ### WARNING
 
-
 # Density - table of variables of LB Node to stream
 #	Velocity-based Evolution d3q27:
 source("lattice.R")
 
+# Densities for initialising with rinside
 AddDensity(name="Init_UX_External", group="init", comment="free stream velocity", parameter=TRUE)
 AddDensity(name="Init_UY_External", group="init", comment="free stream velocity", parameter=TRUE)
 AddDensity(name="Init_UZ_External", group="init", comment="free stream velocity", parameter=TRUE)
 AddDensity(name="Init_PhaseField_External", group="init", dx=0,dy=0,dz=0, parameter=TRUE)
 
+# macroscopic params
+# - consider migrating to fields
 AddDensity(name="pnorm", dx=0, dy=0, dz=0, group="Vel")
 AddDensity(name="U", dx=0, dy=0, dz=0, group="Vel")
 AddDensity(name="V", dx=0, dy=0, dz=0, group="Vel")
 AddDensity(name="W", dx=0, dy=0, dz=0, group="Vel")
 
 # normal direction
+# - consider migrating to fields
 AddDensity(name="nw_x", dx=0, dy=0, dz=0, group="nw")
 AddDensity(name="nw_y", dx=0, dy=0, dz=0, group="nw")
 AddDensity(name="nw_z", dx=0, dy=0, dz=0, group="nw")
@@ -56,7 +59,6 @@ if (Options$staircaseimp) {
     extra_load_phase = c(extra_load_phase, "nw_actual")
     extra_fields_to_load_for_bc = c("nw_actual", "st_interpolation")
 }
-
 
 AddDensity("IsSpecialBoundaryPoint", dx=0, dy=0, dz=0, group="solid_boundary")
 AddQuantity("SpecialBoundaryPoint", unit = 1)

--- a/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
+++ b/models/multiphase/d3q27_pf_velocity/Dynamics.c.Rt
@@ -273,6 +273,8 @@ CudaDeviceFunction void Init()
 	} else {
 		U = VelocityX;	V = VelocityY;	W = VelocityZ;
 	}
+
+	pnorm = 0.0; // initialise as zero and fill in later stage
 }
 
 CudaDeviceFunction void InitFromFieldsStage()
@@ -453,7 +455,6 @@ CudaDeviceFunction void UpdateGlobalMarkers()
     }
 }
 
-
 /*	ITERATION:	*/
 CudaDeviceFunction void Run() 
 {
@@ -516,11 +517,13 @@ CudaDeviceFunction void calc_Fp(real_t *fx, real_t *fy, real_t *fz, real_t press
 	*fy = (-1.0/3.0) * pressure * (Density_h-Density_l) * gPhi.y;
 	*fz = (-1.0/3.0) * pressure * (Density_h-Density_l) * gPhi.z;
 }
+
 CudaDeviceFunction void calc_Fb(real_t *fx, real_t *fy, real_t *fz, real_t rho){
     *fx = (Density_h-rho)*BuoyancyX + rho*GravitationX;
 	*fy = (Density_h-rho)*BuoyancyY + rho*GravitationY;
 	*fz = (Density_h-rho)*BuoyancyZ + rho*GravitationZ;
 }
+
 CudaDeviceFunction void calc_Fs(real_t *fx, real_t *fy, real_t *fz, real_t mu, vector_t gPhi){
 	#ifdef OPTIONS_thermo
 		Temp = Temp(0,0,0);


### PR DESCRIPTION
Currently the density pnorm is part of the Vel group which is saved after the first stage of init, although its value isn't calculated until a later stage. 

To stop the testing error for now, pnorm is initially set to zero in this first stage. Future considerations around moving this and U,V,W to fields rather than densities are highlighted to provide distinction between streamed densities required by the model and fields that are determined from these.