### PR TITLE
RunPython

### DIFF
--- a/src/Handlers/cbRunR.cpp
+++ b/src/Handlers/cbRunR.cpp
@@ -626,6 +626,7 @@ namespace RunR {
 			R["$.CLB"]           = Rcpp::InternalFunction( &CLBDollar );
 			R["[[.CLB"]          = Rcpp::InternalFunction( &CLBDollar );
 			R["$<-.CLB"]         = Rcpp::InternalFunction( &CLBDollarAssign );
+			R["[[<-.CLB"]        = Rcpp::InternalFunction( &CLBDollarAssign );
 			R["print.CLB"]       = Rcpp::InternalFunction( &CLBPrint );
 			R["names.CLB"]       = Rcpp::InternalFunction( &CLBNames );
 			R.parseEval("'CLBFunctionWrap' <- function(obj) { function(...) CLBFunctionCall(obj, list(...)); }");
@@ -820,7 +821,7 @@ int cbRunR::DoIt() {
 // Function created only to check to create Handler for specific conditions
 vHandler * Ask_For_RunR(const pugi::xml_node& node) {
   std::string name = node.name();
-  if (name == "RunR" | name == "RunPython") {
+  if (name == "RunR" || name == "RunPython") {
 #ifdef WITH_R
     return new cbRunR;
 #else

--- a/src/Handlers/cbRunR.cpp
+++ b/src/Handlers/cbRunR.cpp
@@ -5,9 +5,6 @@
 #define rNull Rcpp::NumericVector(0)
 template <typename T> Rcpp::IntegerVector SingleInteger(T i) { Rcpp::IntegerVector v(1); v[0] = i; return v; }
 
-//RInside RunR::R(0,0,true,false,true);
-RInside RunR::R(0,0,true,false,true);
-
 class rWrapper { // Wrapper for all my R objects
 public:
 	Solver * solver;
@@ -613,36 +610,127 @@ void CLB_WriteConsoleEx( const char* message, int len, int oType ){
 }
 }
 
-  #define R_INTERFACE_PTRS
-  #include <Rinterface.h>
+#define R_INTERFACE_PTRS
+#include <Rinterface.h>
 
-int RunR::Init() {
+
+namespace RunR {
+	RInside& GetR() {
+		static RInside * Rptr;
+		if (Rptr == NULL) {
+			notice("R: Initializing R environment ...");
+			Rptr = new RInside(0,0,true,false,true);
+			RInside& R = *Rptr;
+
+			R["CLBFunctionCall"] = Rcpp::InternalFunction( &CLBFunctionCall );
+			R["$.CLB"]           = Rcpp::InternalFunction( &CLBDollar );
+			R["[[.CLB"]          = Rcpp::InternalFunction( &CLBDollar );
+			R["$<-.CLB"]         = Rcpp::InternalFunction( &CLBDollarAssign );
+			R["print.CLB"]       = Rcpp::InternalFunction( &CLBPrint );
+			R["names.CLB"]       = Rcpp::InternalFunction( &CLBNames );
+			R.parseEval("'CLBFunctionWrap' <- function(obj) { function(...) CLBFunctionCall(obj, list(...)); }");
+			ptr_R_WriteConsoleEx = CLB_WriteConsoleEx ;
+			ptr_R_WriteConsole = NULL;
+			R_Outputfile = NULL;
+			R_Consolefile = NULL;
+			R.parseEval("options(prompt='[  ] R:> ');");
+		}
+		return *Rptr;
+	};
+
+	void parseEval(const std::string& source) {
+		RInside& R = GetR();
+		R.parseEval(source);
+	}
+
+	int replInit() {
+		R_ReplDLLinit();
+		return 0;
+	}
+
+	int replDo() {
+		return R_ReplDLLdo1();
+	}
+
+	SEXP wrap_solver(Solver* solver, vHandler * hand) {
+		rWrapper base;
+		base.solver = solver;
+		base.hand = hand;
+		return base.rWrap(new  rSolver ());
+	}
+
+	SEXP wrap_handler(Solver* solver, vHandler * hand, const pugi::xml_node& par) {
+		rWrapper base;
+		base.solver = solver;
+		base.hand = hand;
+		return base.rWrap(new  rXMLNode (par));
+	}
+};
+
+namespace RunPython {
+	bool has_reticulate = false;
+	bool py_initialised = false;
+	void initializePy();
+
+	void parseEval(const std::string& source) {
+		if (! py_initialised) initializePy();
+		Rcpp::Function py_run_string("py_run_string");
+		py_run_string(source);
+		return;
+	}	
+
+	void initializePy() {
+		RInside& R = RunR::GetR();
+		has_reticulate = R.parseEval("require(reticulate, quietly=TRUE)");
+		if (!has_reticulate) throw std::string("Tried to call Python, but no reticulate installed");
+		py_initialised = true;
+		R.parseEval(
+			"py_names = function(obj) names(obj)                                   \n"
+			"py_element = function(obj, name) `[[`(obj,name)                       \n"
+			"py_element_assign = function(obj, name, value) `[[<-`(obj,name,value) \n"
+			"r_to_py.CLB = function(x, convert=FALSE) py$S3(reticulate:::py_capsule(x))\n"
+		);
+		parseEval(
+			"class S3:                                                             \n"
+			"  def __init__(self, obj):                                            \n"
+			"    object.__setattr__(self,'obj',obj)                                \n"
+			"  def print(self):                                                    \n"
+			"    return r.print(self.obj)                                          \n"
+			"  def __dir__(self):                                                  \n"
+			"    return r.py_names(self.obj)                                       \n"
+			"  def __getattr__(self, index):                                       \n"
+			"    if index.startswith('_'):                                         \n"
+			"      return None                                                     \n"
+			"    return r.py_element(self.obj, index)                              \n"
+			"  def __setattr__(self, index, value):                                \n"
+			"    return r.py_element_assign(self.obj, index, value)                \n"
+			"  def __call__(self):                                                 \n"
+			"    raise TypeError('not really callable')                            \n"
+		);
+		R.parseEval(
+			"py$Solver = r_to_py(Solver)"
+		);
+	}
+
+	int replRun() {
+		if (! py_initialised) initializePy();
+		Rcpp::Function repl_python("repl_python");
+		repl_python();
+		return 0;
+	}
+}
+
+int cbRunR::Init() {
 	Callback::Init();
-	notice("R: Initializing R environment ...");
+	RInside& R = RunR::GetR();
+	R["Solver"] = RunR::wrap_solver(solver,this);
 
-	R["CLBFunctionCall"] = Rcpp::InternalFunction( &CLBFunctionCall );
-	R["$.CLB"]           = Rcpp::InternalFunction( &CLBDollar );
-	R["[[.CLB"]          = Rcpp::InternalFunction( &CLBDollar );
-	R["$<-.CLB"]         = Rcpp::InternalFunction( &CLBDollarAssign );
-	R["print.CLB"]       = Rcpp::InternalFunction( &CLBPrint );
-	R["names.CLB"]       = Rcpp::InternalFunction( &CLBNames );
-	R.parseEval("'CLBFunctionWrap' <- function(obj) { function(...) CLBFunctionCall(obj, list(...)); }");
-
-	rWrapper base;
-	base.solver = solver;
-	base.hand = this;
-	R["Solver"]          = base.rWrap(new  rSolver ());
-
-        ptr_R_WriteConsoleEx = CLB_WriteConsoleEx ;
-        ptr_R_WriteConsole = NULL;
-	R_Outputfile = NULL;
-	R_Consolefile = NULL;
-
-	R.parseEval("options(prompt='[  ] R:> ');");
-
+	python = false;
 	interactive = false;
 	echo = true;
 
+	std::string name = node.name();
+	if (name == "RunPython") python = true;
 	pugi::xml_attribute attr;
 	attr = node.attribute("interactive");
 	if (attr) interactive = attr.as_bool();
@@ -654,7 +742,7 @@ int RunR::Init() {
 		if (par.type() == pugi::node_element) {
 			char nd_name[20];
 			sprintf(nd_name, "xml_%0zx", par.hash_value());
-			R[nd_name]          = base.rWrap(new  rXMLNode (par));
+			R[nd_name] = RunR::wrap_handler(solver,this,par);
 			
 			source = source + nd_name + "()\n";
 			output("element\n");
@@ -668,15 +756,12 @@ int RunR::Init() {
 			output("Unknown\n");
 		}
 	}
-//	output("----- RunR -----\n");
-//	output("%s\n",source.c_str());
-//	output("----------------\n");	
 	
 	return 0;
 }
 
 
-int RunR::DoIt() {
+int cbRunR::DoIt() {
 	try {
 		if (source != "") {
 			solver->print("Running R ...");
@@ -685,7 +770,11 @@ int RunR::DoIt() {
 				output("%s\n",source.c_str());
 				output("----------------\n");
 			}
-			R.parseEval(source);
+			if (python) {
+				RunPython::parseEval(source);
+			} else {
+				RunR::parseEval(source);
+			}
 		}
 		if (!interactive) {
 			if (echo) NOTICE("You can run interactive R session with Ctrl+X");
@@ -698,10 +787,21 @@ int RunR::DoIt() {
 			}
 		}
 		if (interactive) {
-			R_ReplDLLinit();
-			while( R_ReplDLLdo1() > 0 ) {}
+			if (python) {
+				RunPython::replRun();
+			} else {
+				RunR::replInit();
+				while( RunR::replDo() > 0 ) {}
+			}
 		}
+	} catch (Rcpp::exception& ex) {
+		ERROR("Caught Rcpp exception");
+		return -1;
+	} catch(std::exception &ex) {	
+		ERROR("Caught std exception: %s", ex.what());
+		return -1;
 	} catch (...) {
+		ERROR("Caught uknown exception");
 		return -1;
 	}
 	return 0;
@@ -713,9 +813,9 @@ int RunR::DoIt() {
 // Function created only to check to create Handler for specific conditions
 vHandler * Ask_For_RunR(const pugi::xml_node& node) {
   std::string name = node.name();
-  if (name == "RunR") {
+  if (name == "RunR" | name == "RunPython") {
 #ifdef WITH_R
-    return new RunR;
+    return new cbRunR;
 #else
     ERROR("No R support. configure with --enable-rinside\n");
     exit(-1);  

--- a/src/Handlers/cbRunR.h
+++ b/src/Handlers/cbRunR.h
@@ -27,6 +27,8 @@ class cbRunR : public  Callback  {
     bool interactive;
     bool echo;
     bool python;
+    static int s_tag;
+    int tag;
 public:
     int Init ();
     int DoIt ();

--- a/src/Handlers/cbRunR.h
+++ b/src/Handlers/cbRunR.h
@@ -22,12 +22,12 @@
 
 #ifdef WITH_R
 
-class RunR : public  Callback  {
+class cbRunR : public  Callback  {
     std::string source;
     bool interactive;
     bool echo;
+    bool python;
 public:
-    static RInside R;
     int Init ();
     int DoIt ();
 };


### PR DESCRIPTION
This PR extends the RunR capabilities with Python execution through the `reticulate`. You can now execute Python code with `<RunPython/>` element, where `Solver` is exposed in the same way as in R.

### Example
```xml
<?xml version="1.0"?>
<CLBConfig version="2.0" output="output/">
	<Geometry nx="1024" ny="100">
		<MRT><Box/></MRT>
		<WVelocity><Box nx="1"/></WVelocity>
		<EPressure><Box dx="-1"/></EPressure>
	</Geometry>
	<Model>
		<Param name="VelocityX" value="0.05"/>
		<Param name="Viscosity" value="0.01"/>
	</Model>
	<RunR Iterations="100">
		print(sum(Solver$Quantities$Rho))
	</RunR>
	<RunPython Iterations="100">
print(Solver.Quantities.Rho.sum())
	</RunPython>
	<Solve Iterations="1000"/>
</CLBConfig>
```

FYI: @TravisMitchell @shkodm @mdzik 
*I think with this present in the code we can get rid of the native Python support.*
