### PR TITLE
Arbitrary grid updates

### DIFF
--- a/src/ArbConnectivity.hpp
+++ b/src/ArbConnectivity.hpp
@@ -30,17 +30,17 @@ struct ArbLatticeConnectivity {
         zones.reserve(getLocalSize());
     }
 
-    void dump(std::string filename) {
+    void dump(std::string filename) const {
         FILE* f;
-        f = fopen(filename.c_str(),"w");
-        fprintf(f,"idx_og,idx");
-        for (size_t q=0;q<Q;q++) fprintf(f,",nbr%ld",q);
-        fprintf(f,"\n");
+        f = fopen(filename.c_str(), "w");
+        fprintf(f, "idx_og,idx");
+        for (size_t q = 0; q < Q; q++) fprintf(f, ",nbr%ld", q);
+        fprintf(f, "\n");
         size_t n = chunk_end - chunk_begin;
-        for (size_t lid=0; lid<n; lid++) {
-            fprintf(f,"%ld,%ld",(size_t) og_index[lid],(size_t) lid + chunk_begin);
-            for (size_t q=0;q<Q;q++) fprintf(f,",%ld",(signed long int) neighbor(q, lid));
-            fprintf(f,"\n");
+        for (size_t lid = 0; lid < n; lid++) {
+            fprintf(f, "%ld,%ld", (size_t)og_index[lid], (size_t)lid + chunk_begin);
+            for (size_t q = 0; q < Q; q++) fprintf(f, ",%ld", (signed long int)neighbor(q, lid));
+            fprintf(f, "\n");
         }
         fclose(f);
     }

--- a/src/ArbLattice.cpp
+++ b/src/ArbLattice.cpp
@@ -14,10 +14,10 @@
 #include "PartitionArbLattice.hpp"
 #include "mpitools.hpp"
 #include "pinned_allocator.hpp"
-
 #include "vtuOutput.h"
 
-ArbLattice::ArbLattice(size_t num_snaps_, const UnitEnv& units_, const std::map<std::string, int>& setting_zones, pugi::xml_node arb_node, MPI_Comm comm_) : LatticeBase(ZONESETTINGS, ZONE_MAX, num_snaps_, units_), comm(comm_) {
+ArbLattice::ArbLattice(size_t num_snaps_, const UnitEnv& units_, const std::map<std::string, int>& setting_zones, pugi::xml_node arb_node, MPI_Comm comm_)
+    : LatticeBase(ZONESETTINGS, ZONE_MAX, num_snaps_, units_), comm(comm_) {
     initialize(num_snaps_, setting_zones, arb_node);
 }
 
@@ -36,84 +36,25 @@ void ArbLattice::initialize(size_t num_snaps_, const std::map<std::string, int>&
     const std::string cxn_path = name_attr.value();
     readFromCxn(cxn_path);
     global_node_dist = computeInitialNodeDist(connect.num_nodes_global, mpitools::MPI_Size(comm));
-    if (debug_name.size() != 0) {
-        connect.dump(formatAsString("%s_P%02d_conn_before.csv", debug_name, rank));
-    }
+    debugDumpConnect("conn_before");
     partition();
-    if (debug_name.size() != 0) {
-        connect.dump(formatAsString("%s_P%02d_conn_after.csv", debug_name, rank));
-    }
-    if (connect.getLocalSize() == 0) throw std::runtime_error{"At least one MPI rank has an empty partition, please use fewer MPI ranks"};  // Realistically, this should never happen
+    debugDumpConnect("conn_after");
+    if (connect.getLocalSize() == 0)
+        throw std::runtime_error{"At least one MPI rank has an empty partition, please use fewer MPI ranks"};  // Realistically, this should never happen
     computeGhostNodes();
     computeLocalPermutation();
     allocDeviceMemory();
     initDeviceData(arb_node, setting_zones);
     local_bounding_box = getLocalBoundingBox();
     vtu_geom = makeVTUGeom();
-    if (debug_name.size() != 0) {
-        std::string filename;
-        size_t i;
-        FILE* f;
-        
-        filename = formatAsString("%s_P%02d_loc_perm.csv", debug_name, rank);
-        f = fopen(filename.c_str(),"w");
-        fprintf(f,"rank,globalIdx,idx\n");
-        i = connect.chunk_begin;
-        for (const auto& idx : local_permutation) {
-            fprintf(f, "%d,%ld,%d\n", rank, i, idx);
-            i++;
-        }
-        assert(i == connect.chunk_end);
-        i = getLocalSize();
-        for (const auto& gidx : ghost_nodes) {
-            fprintf(f, "%d,%ld,%ld\n", rank, gidx, i);
-            i++;
-        }
-        fprintf(f, "%d,%ld,%ld\n", rank, (long int) -1, i);
-        i++;
-        printf("i:%ld snaps_pitch: %ld\n", i, sizes.snaps_pitch); fflush(stdout);
-        assert(i <= sizes.snaps_pitch);
-        fclose(f);
-
-
-        filename = formatAsString("%s_P%02d.vtu", debug_name, rank);
-        const auto& [num_cells, num_points, coords, verts] = getVTUGeom();
-        VtkFileOut vtu_file(filename, num_cells, num_points, coords.get(), verts.get(), MPMD.local, true, false);
-        {
-            std::vector< size_t > tab1(getLocalSize());
-            std::vector< int >    tab2(getLocalSize());
-            std::vector< size_t > tab3(getLocalSize());
-            for (size_t node = 0; node != connect.getLocalSize(); ++node) {
-                auto i = local_permutation.at(node);
-                tab1[i] = node + connect.chunk_begin;
-                tab2[i] = rank;
-                tab3[i] = connect.og_index[node];
-            }
-            vtu_file.writeField("globalId",     tab1.data());
-            vtu_file.writeField("globalIdRank", tab2.data());
-            vtu_file.writeField("globalIdOg", tab3.data());
-        }
-        {
-            std::vector< signed long int > tab1(getLocalSize()*Q);
-            std::vector< int >    tab2(getLocalSize()*Q);
-            for (size_t node = 0; node != connect.getLocalSize(); ++node) {
-                auto i = local_permutation.at(node);
-                for (size_t q = 0; q != Q; ++q) {
-                    const auto nbr = connect.neighbor(q, node);
-                    tab1[i * Q + q] = nbr;
-                    const int owner = std::distance(global_node_dist.cbegin(), std::upper_bound(global_node_dist.cbegin(), global_node_dist.cend(), nbr)) - 1;
-                    tab2[i * Q + q] = owner;
-                }
-            }
-            vtu_file.writeField("neighbour",     tab1.data(), Q);
-            vtu_file.writeField("neighbourRank", tab2.data(), Q);
-        }
-        vtu_file.writeFooters();
-    }
+    debugDumpVTU();
     initCommManager();
     initContainer();
 
-    debug1("Initialized arbitrary lattice with: border nodes=%lu; interior nodes=%lu; ghost nodes=%lu", sizes.border_nodes, getLocalSize() - sizes.border_nodes, ghost_nodes.size());
+    debug1("Initialized arbitrary lattice with: border nodes=%lu; interior nodes=%lu; ghost nodes=%lu",
+           sizes.border_nodes,
+           getLocalSize() - sizes.border_nodes,
+           ghost_nodes.size());
 }
 
 int ArbLattice::reinitialize(size_t num_snaps_, const std::map<std::string, int>& setting_zones, pugi::xml_node arb_node) {
@@ -138,7 +79,9 @@ void ArbLattice::readFromCxn(const std::string& cxn_path) {
 
     // Open file + utils for error reporting
     std::fstream file(cxn_path, std::ios_base::in);
-    const auto wrap_err_msg = [&](std::string msg) { return "Error while reading "s.append(cxn_path.c_str()).append(" on MPI rank ").append(std::to_string(comm_rank)).append(": ").append(msg); };
+    const auto wrap_err_msg = [&](std::string msg) {
+        return "Error while reading "s.append(cxn_path.c_str()).append(" on MPI rank ").append(std::to_string(comm_rank)).append(": ").append(msg);
+    };
     const auto check_file_ok = [&](const std::string& err_message = "Unknown error") {
         if (!file) throw std::ios_base::failure(wrap_err_msg(err_message));
     };
@@ -189,7 +132,12 @@ void ArbLattice::readFromCxn(const std::string& cxn_path) {
             const auto prov_it = std::find(q_provided.cbegin(), q_provided.cend(), req);
             if (prov_it == q_provided.cend()) {
                 const auto [x, y, z] = req;
-                const auto err_msg = "The arbitrary lattice file does not provide the required direction: ["s.append(std::to_string(x)).append(", ").append(std::to_string(y)).append(", ").append(std::to_string(z)).append("]");
+                const auto err_msg = "The arbitrary lattice file does not provide the required direction: ["s.append(std::to_string(x))
+                                         .append(", ")
+                                         .append(std::to_string(y))
+                                         .append(", ")
+                                         .append(std::to_string(z))
+                                         .append("]");
                 throw std::runtime_error(wrap_err_msg(err_msg));
             }
             req_prov_perm[i++] = std::distance(q_provided.cbegin(), prov_it);
@@ -253,7 +201,10 @@ void ArbLattice::readFromCxn(const std::string& cxn_path) {
 void ArbLattice::partition() {
     if (mpitools::MPI_Size(comm) == 1) return;
 
-    const auto zero_dir_ind = std::distance(Model_m::offset_directions.cbegin(), std::find(Model_m::offset_directions.cbegin(), Model_m::offset_directions.cend(), OffsetDir{0, 0, 0}));  // Note: the behavior is still correct even if (0,0,0) is not an offset direction
+    const auto zero_dir_ind = std::distance(Model_m::offset_directions.cbegin(),
+                                            std::find(Model_m::offset_directions.cbegin(),
+                                                      Model_m::offset_directions.cend(),
+                                                      OffsetDir{0, 0, 0}));  // Note: the behavior is still correct even if (0,0,0) is not an offset direction
     const auto offset_dir_wgts = std::vector(Model_m::offset_direction_weights.begin(), Model_m::offset_direction_weights.end());
     auto [dist, log] = partitionArbLattice(connect, offset_dir_wgts, zero_dir_ind, comm);
     for (const auto& [type, msg] : log) switch (type) {
@@ -280,7 +231,7 @@ void ArbLattice::computeGhostNodes() {
 }
 
 void ArbLattice::computeLocalPermutation() {
-    std::vector< size_t > lids; // globalIdx - chunk_begin of elements
+    std::vector<size_t> lids;  // globalIdx - chunk_begin of elements
     lids.resize(connect.getLocalSize());
     std::iota(lids.begin(), lids.end(), 0);
     const auto is_border_node = [&](int lid) {
@@ -300,10 +251,7 @@ void ArbLattice::computeLocalPermutation() {
     std::sort(interior_begin, lids.end(), by_zyx);
     local_permutation.resize(connect.getLocalSize());
     size_t i = 0;
-    for (const auto& lid : lids) {
-        local_permutation[lid] = i;
-        i++;
-    }
+    for (const auto& lid : lids) local_permutation[lid] = i++;
 }
 
 void ArbLattice::allocDeviceMemory() {
@@ -322,7 +270,8 @@ std::vector<ArbLattice::NodeTypeBrush> ArbLattice::parseBrushFromXml(pugi::xml_n
     std::vector<ArbLattice::NodeTypeBrush> retval;
     for (auto node = arb_node.first_child(); node; node = node.next_sibling()) {
         // Requested node type
-        const auto ntf_iter = std::find_if(model->nodetypeflags.cbegin(), model->nodetypeflags.cend(), [name = node.name()](const auto& ntf) { return ntf.name == name; });
+        const auto ntf_iter =
+            std::find_if(model->nodetypeflags.cbegin(), model->nodetypeflags.cend(), [name = node.name()](const auto& ntf) { return ntf.name == name; });
         if (ntf_iter == model->nodetypeflags.cend()) throw std::runtime_error{formatAsString("Unknown node type: %s", node.name())};
 
         // Determine what kind of node we're parsing and update the brush accordingly
@@ -333,12 +282,16 @@ std::vector<ArbLattice::NodeTypeBrush> ArbLattice::parseBrushFromXml(pugi::xml_n
             const flag_t value = ntf_iter->flag | (zone_attr ? (setting_zones.at(zone_attr.value()) << model->settingzones.shift) : 0);
             const std::string group_name = group_attr.value();
             const auto label_iter = label_to_ind_map.find(group_name);
-            if (label_iter == label_to_ind_map.end()) throw std::runtime_error{formatAsString("The required label %s is missing from the .cxn file", group_name)};
+            if (label_iter == label_to_ind_map.end())
+                throw std::runtime_error{formatAsString("The required label %s is missing from the .cxn file", group_name)};
             const auto label = label_iter->second;
-            const auto has_label = [label](Span<const ArbLatticeConnectivity::ZoneIndex> labels, std::array<double, 3>) { return std::find(labels.begin(), labels.end(), label) != labels.end(); };
+            const auto has_label = [label](Span<const ArbLatticeConnectivity::ZoneIndex> labels, std::array<double, 3>) {
+                return std::find(labels.begin(), labels.end(), label) != labels.end();
+            };
             retval.push_back(NodeTypeBrush{has_label, mask, value});
         } else
-            throw std::runtime_error{std::string("The ArbitraryLattice XML node contains an incorrectly specified child named ") + node.name()};  // TODO: implement other node types, e.g. <Box>
+            throw std::runtime_error{std::string("The ArbitraryLattice XML node contains an incorrectly specified child named ") +
+                                     node.name()};  // TODO: implement other node types, e.g. <Box>
     }
     return retval;
 }
@@ -347,7 +300,9 @@ void ArbLattice::computeNodeTypesOnHost(pugi::xml_node arb_node, const std::map<
     const auto local_sz = connect.getLocalSize();
     const auto zone_sizes = Span(connect.zones_per_node.get(), local_sz);
     auto zone_offsets = std::vector<size_t>(local_sz);
-    std::transform_exclusive_scan(zone_sizes.begin(), zone_sizes.end(), zone_offsets.begin(), size_t{0}, std::plus{}, [](auto label) -> size_t { return label; });  // labels are stored as a short type, we need to cast it to size_t before computing the scan
+    std::transform_exclusive_scan(zone_sizes.begin(), zone_sizes.end(), zone_offsets.begin(), size_t{0}, std::plus{}, [](auto label) -> size_t {
+        return label;
+    });  // labels are stored as a short type, we need to cast it to size_t before computing the scan
     const auto brushes = parseBrushFromXml(arb_node, setting_zones);
     node_types_host = std::pmr::vector<flag_t>(local_sz, &global_pinned_resource);
     for (size_t i = 0; i != local_sz; ++i) {
@@ -446,11 +401,13 @@ int ArbLattice::fullLatticePos(double pos) const {
 
 lbRegion ArbLattice::getLocalBoundingBox() const {
     const auto local_sz = connect.getLocalSize();
-    const Span x(connect.coords.get(), local_sz), y(std::next(connect.coords.get(), local_sz), local_sz), z(std::next(connect.coords.get(), 2 * local_sz), local_sz);
+    const Span x(connect.coords.get(), local_sz), y(std::next(connect.coords.get(), local_sz), local_sz),
+        z(std::next(connect.coords.get(), 2 * local_sz), local_sz);
     const auto [minx_it, maxx_it] = std::minmax_element(x.begin(), x.end());
     const auto [miny_it, maxy_it] = std::minmax_element(y.begin(), y.end());
     const auto [minz_it, maxz_it] = std::minmax_element(z.begin(), z.end());
-    const int x_min = fullLatticePos(*minx_it), x_max = fullLatticePos(*maxx_it), y_min = fullLatticePos(*miny_it), y_max = fullLatticePos(*maxy_it), z_min = fullLatticePos(*minz_it), z_max = fullLatticePos(*maxz_it);
+    const int x_min = fullLatticePos(*minx_it), x_max = fullLatticePos(*maxx_it), y_min = fullLatticePos(*miny_it), y_max = fullLatticePos(*maxy_it),
+              z_min = fullLatticePos(*minz_it), z_max = fullLatticePos(*maxz_it);
     return lbRegion(x_min, y_min, z_min, x_max - x_min + 1, y_max - y_min + 1, z_max - z_min + 1);
 }
 
@@ -463,7 +420,14 @@ ArbLattice::ArbVTUGeom ArbLattice::makeVTUGeom() const {
     const auto get_bb_verts = [&](unsigned node) {
         const double x = connect.coord(0, node), y = connect.coord(1, node), z = connect.coord(2, node);
         const int posx = fullLatticePos(x), posy = fullLatticePos(y), posz = fullLatticePos(z);
-        static constexpr std::array offsets = {std::array{0, 0, 0}, std::array{1, 0, 0}, std::array{1, 1, 0}, std::array{0, 1, 0}, std::array{0, 0, 1}, std::array{1, 0, 1}, std::array{1, 1, 1}, std::array{0, 1, 1}};  // We need a specific ordering to agree with the vtu spec
+        static constexpr std::array offsets = {std::array{0, 0, 0},
+                                               std::array{1, 0, 0},
+                                               std::array{1, 1, 0},
+                                               std::array{0, 1, 0},
+                                               std::array{0, 0, 1},
+                                               std::array{1, 0, 1},
+                                               std::array{1, 1, 1},
+                                               std::array{0, 1, 1}};  // We need a specific ordering to agree with the vtu spec
         std::array<Index, 8> retval{};
         std::transform(offsets.begin(), offsets.end(), retval.begin(), [&](const auto& ofs) {
             const auto [dx, dy, dz] = ofs;
@@ -482,7 +446,10 @@ ArbLattice::ArbVTUGeom ArbLattice::makeVTUGeom() const {
         return retval;
     });
 
-    ArbVTUGeom retval{connect.getLocalSize(), full_to_red_map.size(), std::make_unique<double[]>(full_to_red_map.size() * 3), std::make_unique<unsigned[]>(connect.getLocalSize() * 8)};
+    ArbVTUGeom retval{connect.getLocalSize(),
+                      full_to_red_map.size(),
+                      std::make_unique<double[]>(full_to_red_map.size() * 3),
+                      std::make_unique<unsigned[]>(connect.getLocalSize() * 8)};
     // Iterating across the entire bounding box is a bit hairy, but saves memory compared to the alternative (and we only do it once)
     for (Index vx = sx; vx != nx + sx; ++vx)
         for (Index vy = sy; vy != ny + sy; ++vy)
@@ -531,8 +498,8 @@ void ArbLattice::getQuantity(int quant, real_t* host_tab, real_t scale) {
 void ArbLattice::initCommManager() {
     if (mpitools::MPI_Size(comm) == 1) return;
     int rank = mpitools::MPI_Rank(comm);
-     const auto& field_table = Model_m::field_streaming_table;
-    using NodeFieldP = std::array<size_t, 2>;              // Node + field index. We can be a bit wasteful with storing both as 64b, since the number of border nodes is relatively small
+    const auto& field_table = Model_m::field_streaming_table;
+    using NodeFieldP = std::array<size_t, 2>;              // Node + field index
     std::map<int, std::vector<NodeFieldP>> needed_fields;  // in_nbrs to required N-F pairs, **we need it to be sorted**
     for (size_t node = 0; node != connect.getLocalSize(); ++node) {
         for (size_t q = 0; q != Q; ++q) {
@@ -550,7 +517,8 @@ void ArbLattice::initCommManager() {
         vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
         comm_manager.in_nbrs.emplace_back(id, vec.size());
     }
-    size_t recv_buf_size = std::transform_reduce(comm_manager.in_nbrs.cbegin(), comm_manager.in_nbrs.cend(), size_t{0}, std::plus{}, [](auto p) { return p.second; });
+    const size_t recv_buf_size =
+        std::transform_reduce(comm_manager.in_nbrs.cbegin(), comm_manager.in_nbrs.cend(), size_t{0}, std::plus{}, [](auto p) { return p.second; });
     comm_manager.recv_buf_host = std::pmr::vector<storage_t>(recv_buf_size, &global_pinned_resource);
     comm_manager.recv_buf_device = cudaMakeUnique<storage_t>(recv_buf_size);
     comm_manager.unpack_inds = cudaMakeUnique<size_t>(recv_buf_size);
@@ -574,11 +542,12 @@ void ArbLattice::initCommManager() {
         if (sz != 0) comm_manager.out_nbrs.emplace_back(out_id, sz);
         ++out_id;
     }
-    size_t send_buf_size = std::transform_reduce(comm_manager.out_nbrs.cbegin(), comm_manager.out_nbrs.cend(), size_t{0}, std::plus{}, [](auto p) { return p.second; });
+    size_t send_buf_size =
+        std::transform_reduce(comm_manager.out_nbrs.cbegin(), comm_manager.out_nbrs.cend(), size_t{0}, std::plus{}, [](auto p) { return p.second; });
     comm_manager.send_buf_host = std::pmr::vector<storage_t>(send_buf_size, &global_pinned_resource);
     comm_manager.send_buf_device = cudaMakeUnique<storage_t>(send_buf_size);
     comm_manager.pack_inds = cudaMakeUnique<size_t>(send_buf_size);
- 
+
     std::map<int, std::vector<NodeFieldP>> requested_fields;
     for (const auto& [id, sz] : comm_manager.out_nbrs) {
         auto& rf = requested_fields[id];
@@ -586,16 +555,8 @@ void ArbLattice::initCommManager() {
     }
     std::vector<MPI_Request> reqs;
     reqs.reserve(requested_fields.size() + needed_fields.size());
-    for (      auto& [id, rf] : requested_fields) {
-        MPI_Request req;
-        MPI_Irecv(rf.data(), rf.size() * 2, mpitools::getMPIType<size_t>(), id, 0, comm, &req);
-        reqs.push_back(req);
-    }
-    for (const auto& [id, nf] : needed_fields) {
-        MPI_Request req;
-        MPI_Isend(nf.data(), nf.size() * 2, mpitools::getMPIType<size_t>(), id, 0, comm, &req);
-        reqs.push_back(req);
-    }
+    for (auto& [id, rf] : requested_fields) MPI_Irecv(rf.data(), rf.size() * 2, mpitools::getMPIType<size_t>(), id, 0, comm, &reqs.emplace_back());
+    for (const auto& [id, nf] : needed_fields) MPI_Isend(nf.data(), nf.size() * 2, mpitools::getMPIType<size_t>(), id, 0, comm, &reqs.emplace_back());
     MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
     std::pmr::vector<size_t> pack_inds_host(send_buf_size, &global_pinned_resource);
     auto pack_ind_iter = pack_inds_host.begin();
@@ -619,8 +580,8 @@ void ArbLattice::initCommManager() {
         size_t i;
         FILE* f;
         filename = formatAsString("%s_P%02d_pack.csv", debug_name, rank);
-        f = fopen(filename.c_str(),"w");
-        fprintf(f,"rank,id,globalIdx,field,idx\n");
+        f = fopen(filename.c_str(), "w");
+        fprintf(f, "rank,id,globalIdx,field,idx\n");
         i = 0;
         for (const auto& [id, nfps] : requested_fields) {
             for (const auto& [node, field] : nfps) {
@@ -633,8 +594,8 @@ void ArbLattice::initCommManager() {
         assert(i == pack_inds_host.size());
         fclose(f);
         filename = formatAsString("%s_P%02d_unpack.csv", debug_name, rank);
-        f = fopen(filename.c_str(),"w");
-        fprintf(f,"rank,id,globalIdx,field,idx\n");
+        f = fopen(filename.c_str(), "w");
+        fprintf(f, "rank,id,globalIdx,field,idx\n");
         i = 0;
         for (const auto& [id, nfps] : needed_fields) {
             for (const auto& [node, field] : nfps) {
@@ -646,9 +607,7 @@ void ArbLattice::initCommManager() {
         }
         assert(i == unpack_inds_host.size());
         fclose(f);
-
     }
-
 }
 
 void ArbLattice::communicateBorder() {
@@ -670,14 +629,22 @@ void ArbLattice::communicateBorder() {
 void ArbLattice::MPIStream_A() {
     if (mpitools::MPI_Size(comm) == 1) return;
     launcher.pack(outStream);
-    CudaMemcpyAsync(comm_manager.send_buf_host.data(), comm_manager.send_buf_device.get(), comm_manager.send_buf_host.size() * sizeof(storage_t), CudaMemcpyDeviceToHost, outStream);
+    CudaMemcpyAsync(comm_manager.send_buf_host.data(),
+                    comm_manager.send_buf_device.get(),
+                    comm_manager.send_buf_host.size() * sizeof(storage_t),
+                    CudaMemcpyDeviceToHost,
+                    outStream);
 }
 
 void ArbLattice::MPIStream_B() {
     if (mpitools::MPI_Size(comm) == 1) return;
     CudaStreamSynchronize(outStream);
     communicateBorder();
-    CudaMemcpyAsync(comm_manager.recv_buf_device.get(), comm_manager.recv_buf_host.data(), comm_manager.recv_buf_host.size() * sizeof(storage_t), CudaMemcpyHostToDevice, inStream);
+    CudaMemcpyAsync(comm_manager.recv_buf_device.get(),
+                    comm_manager.recv_buf_host.data(),
+                    comm_manager.recv_buf_host.size() * sizeof(storage_t),
+                    CudaMemcpyHostToDevice,
+                    inStream);
     launcher.unpack(inStream);
     CudaStreamSynchronize(inStream);
 }
@@ -716,3 +683,71 @@ void ArbLattice::clearAdjoint() {
     zSet.ClearGrad();
 }
 /// TODO section end
+
+void ArbLattice::debugDumpConnect(const std::string& name) const {
+    if (debug_name.size() != 0) connect.dump(formatAsString("%s_P%02d_%s.csv", debug_name, mpitools::MPI_Rank(comm), name));
+}
+
+void ArbLattice::debugDumpVTU() const {
+    if (debug_name.size() != 0) {
+        std::string filename;
+        size_t i;
+        FILE* f;
+
+        const int rank = mpitools::MPI_Rank(comm);
+        filename = formatAsString("%s_P%02d_loc_perm.csv", debug_name, rank);
+        f = fopen(filename.c_str(), "w");
+        fprintf(f, "rank,globalIdx,idx\n");
+        i = connect.chunk_begin;
+        for (const auto& idx : local_permutation) {
+            fprintf(f, "%d,%ld,%d\n", rank, i, idx);
+            i++;
+        }
+        assert(i == connect.chunk_end);
+        i = getLocalSize();
+        for (const auto& gidx : ghost_nodes) {
+            fprintf(f, "%d,%ld,%ld\n", rank, gidx, i);
+            i++;
+        }
+        fprintf(f, "%d,%ld,%ld\n", rank, (long int)-1, i);
+        i++;
+        printf("i:%ld snaps_pitch: %ld\n", i, sizes.snaps_pitch);
+        fflush(stdout);
+        assert(i <= sizes.snaps_pitch);
+        fclose(f);
+
+        filename = formatAsString("%s_P%02d.vtu", debug_name, rank);
+        const auto& [num_cells, num_points, coords, verts] = getVTUGeom();
+        VtkFileOut vtu_file(filename, num_cells, num_points, coords.get(), verts.get(), MPMD.local, true, false);
+        {
+            std::vector<size_t> tab1(getLocalSize());
+            std::vector<int> tab2(getLocalSize());
+            std::vector<size_t> tab3(getLocalSize());
+            for (size_t node = 0; node != connect.getLocalSize(); ++node) {
+                auto i = local_permutation.at(node);
+                tab1[i] = node + connect.chunk_begin;
+                tab2[i] = rank;
+                tab3[i] = connect.og_index[node];
+            }
+            vtu_file.writeField("globalId", tab1.data());
+            vtu_file.writeField("globalIdRank", tab2.data());
+            vtu_file.writeField("globalIdOg", tab3.data());
+        }
+        {
+            std::vector<signed long int> tab1(getLocalSize() * Q);
+            std::vector<int> tab2(getLocalSize() * Q);
+            for (size_t node = 0; node != connect.getLocalSize(); ++node) {
+                auto i = local_permutation.at(node);
+                for (size_t q = 0; q != Q; ++q) {
+                    const auto nbr = connect.neighbor(q, node);
+                    tab1[i * Q + q] = nbr;
+                    const int owner = std::distance(global_node_dist.cbegin(), std::upper_bound(global_node_dist.cbegin(), global_node_dist.cend(), nbr)) - 1;
+                    tab2[i * Q + q] = owner;
+                }
+            }
+            vtu_file.writeField("neighbour", tab1.data(), Q);
+            vtu_file.writeField("neighbourRank", tab2.data(), Q);
+        }
+        vtu_file.writeFooters();
+    }
+}

--- a/src/ArbLattice.hpp
+++ b/src/ArbLattice.hpp
@@ -137,6 +137,8 @@ class ArbLattice : public LatticeBase {
     ArbVTUGeom makeVTUGeom() const;                                                                                                /// Compute VTU geometry
     void communicateBorder();                                                                                                      /// Send and receive border values in snap (overlapped with interior computation)
     unsigned lookupLocalGhostIndex(ArbLatticeConnectivity::Index gid) const;                                                       /// For a given ghost gid, look up its local id
+    void debugDumpConnect(const std::string& name) const;                                                                          /// Dump connectivity info for debug purposes
+    void debugDumpVTU() const;                                                                                                     /// Dump VTU info info for debug purposes
 };
 
 #endif  // ARBLATTICE_HPP

--- a/src/ArbLattice.hpp
+++ b/src/ArbLattice.hpp
@@ -107,6 +107,7 @@ class ArbLattice : public LatticeBase {
     };
 
     storage_t* getSnapPtr(int snap_ind);  /// Get device pointer to the specified snap (somewhere within the total snap allocation)
+    const storage_t* getSnapPtr(int snap_ind) const { return const_cast<ArbLattice*>(this)->getSnapPtr(snap_ind); }
 #ifdef ADJOINT
     storage_t* getAdjointSnapPtr(int snap_ind);  /// Get device pointer to the specified adjoint snap, snap_ind must be 0 or 1
 #endif

--- a/src/ArbLattice.hpp
+++ b/src/ArbLattice.hpp
@@ -85,6 +85,8 @@ class ArbLattice : public LatticeBase {
     void getQuantity(int quant, real_t* host_tab, real_t scale);  /// Write GPU data to \p host_tab
     const ArbVTUGeom& getVTUGeom() const { return vtu_geom; }
     Span<const flag_t> getNodeTypes() const { return {node_types_host.data(), node_types_host.size()}; }  /// Get host view of node types (permuted)
+    const ArbLatticeConnectivity& getConnectivity() const { return connect; }
+    const std::vector<unsigned>& getLocalPermutation() const { return local_permutation; }
 
    protected:
     ArbLatticeLauncher launcher;  /// Launcher responsible for running CUDA kernels on the lattice

--- a/src/ArbLattice.hpp
+++ b/src/ArbLattice.hpp
@@ -122,11 +122,12 @@ class ArbLattice : public LatticeBase {
     void initialize(size_t num_snaps_, const std::map<std::string, int>& setting_zones, pugi::xml_node arb_node);                  /// Init based on args
     void readFromCxn(const std::string& cxn_path);                                                                                 /// Read the lattice info from a .cxn file
     void partition();                                                                                                              /// Repartition the lattice, if ParMETIS is not present this is a noop
-    void computeLocalPermutation();                                                                                                /// Compute the local permutation, see comment at the top
+    std::function<bool(int, int)> makePermCompare(pugi::xml_node arb_node, const std::map<std::string, int>& setting_zones);       /// Make type-erased comparison operator for computing the local permutation, according to the strategy specified in the xml file
+    void computeLocalPermutation(pugi::xml_node arb_node, const std::map<std::string, int>& setting_zones);                        /// Compute the local permutation, see comment at the top
     void computeGhostNodes();                                                                                                      /// Retrieve GIDs of ghost nodes from the connectivity info structure
     void allocDeviceMemory();                                                                                                      /// Allocate required device memory
     std::vector<NodeTypeBrush> parseBrushFromXml(pugi::xml_node arb_node, const std::map<std::string, int>& setting_zones) const;  /// Parse the arbitrary lattice XML to determine the brush sequence to be applied to each node
-    void computeNodeTypesOnHost(pugi::xml_node arb_node, const std::map<std::string, int>& setting_zones);                         /// Compute the node types to be stored on the device
+    void computeNodeTypesOnHost(pugi::xml_node arb_node, const std::map<std::string, int>& setting_zones, bool permute);           /// Compute the node types to be stored on the device, `permute` enables better code reuse
     std::pmr::vector<real_t> computeCoords() const;                                                                                /// Compute the coordinates 2D array to be stored on the device
     std::pmr::vector<unsigned> computeNeighbors() const;                                                                           /// Compute the neighbors 2D array to be stored on the device
     void initDeviceData(pugi::xml_node arb_node, const std::map<std::string, int>& setting_zones);                                 /// Initialize data residing in device memory

--- a/src/Handlers/acLoadMemoryDump.cpp
+++ b/src/Handlers/acLoadMemoryDump.cpp
@@ -2,25 +2,20 @@
 std::string acLoadMemoryDump::xmlname = "LoadMemoryDump";
 #include "../HandlerFactory.h"
 
-int acLoadMemoryDump::Init () {
-		Action::Init();
-		pugi::xml_attribute attr = node.attribute("file");
-		if (!attr) {
-			attr = node.attribute("filename");
-			if (!attr) {
-				error("No file specified in LoadMemoryDump\n");
-				return -1;
-			}
-		}
-		pugi::xml_attribute attr2= node.attribute("comp");
-		if (attr2) {
-            error("Depreceted API call. Use LoadBinary with comp parameter");
+int acLoadMemoryDump::Init() {
+    Action::Init();
+    pugi::xml_attribute attr = node.attribute("file");
+    if (!attr) {
+        attr = node.attribute("filename");
+        if (!attr) {
+            error("No file specified in LoadMemoryDump\n");
+            return EXIT_FAILURE;
         }
-        const auto lattice = solver->getCartLattice();
-        lattice->loadSolution(attr.value());
-        return 0;
+    }
+    if (node.attribute("comp")) error("Deprecated API call. Use LoadBinary with comp parameter");
+    solver->lattice->loadSolution(attr.value());
+    return EXIT_SUCCESS;
 }
 
-
 // Register the handler (basing on xmlname) in the Handler Factory
-template class HandlerFactory::Register< GenericAsk< acLoadMemoryDump > >;
+template class HandlerFactory::Register<GenericAsk<acLoadMemoryDump> >;

--- a/src/Handlers/cbBIN.cpp
+++ b/src/Handlers/cbBIN.cpp
@@ -3,21 +3,18 @@ std::string cbBIN::xmlname = "BIN";
 #include "../HandlerFactory.h"
 #include "../vtkLattice.h"
 
-int cbBIN::Init () {
-		Callback::Init();
-		pugi::xml_attribute attr = node.attribute("name");
-		nm = "BIN";
-		if (attr) nm = attr.value();
-		return 0;
-	}
+int cbBIN::Init() {
+    Callback::Init();
+    pugi::xml_attribute attr = node.attribute("name");
+    nm = attr ? attr.value() : "BIN";
+    return 0;
+}
 
-
-int cbBIN::DoIt () {
-		Callback::DoIt();
-                const auto filename = solver->outIterFile(nm, "");
-                return binWriteLattice(filename, *solver->getCartLattice(), solver->units);
-	};
-
+int cbBIN::DoIt() {
+    Callback::DoIt();
+    const auto filename = solver->outIterFile(nm, "");
+    return std::visit([&](const auto lattice_ptr) { return binWriteLattice(filename, *lattice_ptr, solver->units); }, solver->getLatticeVariant());
+};
 
 // Register the handler (basing on xmlname) in the Handler Factory
-template class HandlerFactory::Register< GenericAsk< cbBIN > >;
+template class HandlerFactory::Register<GenericAsk<cbBIN> >;

--- a/src/Handlers/cbFailcheck.cpp
+++ b/src/Handlers/cbFailcheck.cpp
@@ -2,102 +2,80 @@
 
 std::string cbFailcheck::xmlname = "Failcheck";
 
-int cbFailcheck::Init () {
-	Callback::Init();
-	currentlyactive = false;
-        const auto lattice = solver->getCartLattice();
-	reg.dx = lattice->getLocalRegion().dx;
-	reg.dy = lattice->getLocalRegion().dy;
-	reg.dz = lattice->getLocalRegion().dz;
-	
+int cbFailcheck::Init() {
+    Callback::Init();
+    currentlyactive = false;
+    const auto init_cart = [&](const Lattice<CartLattice>* lattice) {
+        reg.dx = lattice->getLocalRegion().dx;
+        reg.dy = lattice->getLocalRegion().dy;
+        reg.dz = lattice->getLocalRegion().dz;
+        const auto set_if_present = [&](const char* name, auto& value) {
+            const auto attribute = node.attribute(name);
+            if (attribute) value = solver->units.alt(attribute.value());
+        };
+        set_if_present("dx", reg.dx);
+        set_if_present("dy", reg.dy);
+        set_if_present("dz", reg.dz);
+        set_if_present("nx", reg.nx);
+        set_if_present("ny", reg.ny);
+        set_if_present("nz", reg.nz);
+        return EXIT_SUCCESS;
+    };
+    const auto init_arb = [&](const Lattice<ArbLattice>*) { return EXIT_SUCCESS; };
+    return std::visit(OverloadSet{init_cart, init_arb}, solver->getLatticeVariant());
+}
 
+int cbFailcheck::DoIt() {
+    Callback::DoIt();
+    if (currentlyactive) return EXIT_SUCCESS;
+    currentlyactive = true;
 
-        pugi::xml_attribute attr = node.attribute("dx");
-        if (attr) {
-            reg.dx = solver->units.alt(attr.value());
+    name_set components;
+    const auto comp = node.attribute("what");
+    components.add_from_string(comp ? comp.value() : "all", ',');
+
+    const auto check_for_nans = [&](const Model::Quantity& quantity) -> bool {
+        if (!components.in(quantity.name) || quantity.isAdjoint) return false;
+
+        const auto get_quantity_vec = [&](int quant_id, int n_comps) -> std::vector<real_t> {
+            const auto get_from_cart = [&](Lattice<CartLattice>* lattice) {
+                std::vector<real_t> retval(reg.size() * n_comps);
+                lattice->GetQuantity(quant_id, reg, retval.data(), 1.);
+                return retval;
+            };
+            const auto get_from_arb = [&](Lattice<ArbLattice>* lattice) {
+                std::vector<real_t> retval(lattice->getLocalSize() * n_comps);
+                lattice->getQuantity(quant_id, retval.data(), 1.);
+                return retval;
+            };
+            return std::visit(OverloadSet{get_from_cart, get_from_arb}, solver->getLatticeVariant());
+        };
+
+        const int n_comps = quantity.isVector ? 3 : 1;
+        const auto values = get_quantity_vec(quantity.id, n_comps);
+        int has_nans = std::any_of(values.begin(), values.end(), [](auto v) { return std::isnan(v); });
+        MPI_Allreduce(MPI_IN_PLACE, &has_nans, 1, MPI_INT, MPI_LOR, MPMD.local);
+        if (has_nans) notice("Discovered NaN values in %s", quantity.name.c_str());
+        return has_nans;
+    };
+
+    // Note: std::any_of would break early, we want to print all quantities which have NaN values, hence std::transform_reduce
+    const auto& quants = solver->lattice->model->quantities;
+    if (std::transform_reduce(quants.begin(), quants.end(), false, std::logical_or{}, check_for_nans)) {
+        notice("NaN value discovered. Executing final actions from the Failcheck element before full stop...\n");
+        for (pugi::xml_node par = node.first_child(); par; par = par.next_sibling()) {
+            Handler hand(par, solver);
+            if (hand) hand.DoIt();
         }
-        attr = node.attribute("dy");
-        if (attr) {
-            reg.dy = solver->units.alt(attr.value());
-        }
-        attr = node.attribute("dz");
-        if (attr) {
-            reg.dz = solver->units.alt(attr.value());
-        }
+        notice("Stopping due to NaN value\n");
+        return ITERATION_STOP;
+    }
+    return EXIT_SUCCESS;
+}
 
-
-        attr = node.attribute("nx");
-        if (attr) {
-            reg.nx = solver->units.alt(attr.value());
-        }
-        attr = node.attribute("ny");
-        if (attr) {
-            reg.ny = solver->units.alt(attr.value());
-        }
-        attr = node.attribute("nz");
-        if (attr) {
-            reg.nz = solver->units.alt(attr.value());
-        }
-
-		return 0;
-	}
-
-
-int cbFailcheck::DoIt () {
-		Callback::DoIt();
-	if (currentlyactive) return 0;
-	currentlyactive = true;
-       	int ret = 0;
-		int fin;
-		fin = false;
-
-        pugi::xml_attribute comp = node.attribute("what");
- 
-        name_set components;
-        if(comp){
-            components.add_from_string(comp.value(),',');
-        } else {
-            components.add_from_string("all",',');
-        }
-
-	for (const Model::Quantity& it : solver->lattice->model->quantities) {
-		if (it.isAdjoint) continue;
-            if (components.in(it.name)) {
-			int comp = 1;
-			if (it.isVector) comp = 3;
-                    real_t* tmp = new real_t[reg.size()*comp];
-		    solver->getCartLattice()->GetQuantity(it.id, reg, tmp, 1);
-                    bool cond = false;
-                    for (int k = 0; k < reg.size()*comp; k++){  
-	       		    cond = cond || (std::isnan(tmp[k]));
-                    }
-		    delete[] tmp;
-			MPI_Allreduce(&cond,&fin,1,MPI_INT,MPI_LOR,MPMD.local);
-
-                    if(fin ){
-			notice("Checking %s discovered NaN", it.name.c_str());
-			break;
-			}
-		}
-
-        }
-	    if (fin) {
-			notice("NaN value discovered. Executing final actions from the Failcheck element before full stop...\n");
-                for (pugi::xml_node par = node.first_child(); par; par = par.next_sibling()) {
-                    Handler hand(par, solver);
-                    if (hand) hand.DoIt();
-                }
-                notice("Stopping due to Nan value\n");
-                ret = ITERATION_STOP;
-            }
-            return ret;
-    }	
-
-
-int cbFailcheck::Finish () {
-		return Callback::Finish();
-	}
-
+int cbFailcheck::Finish() {
+    return Callback::Finish();
+}
 
 // Register the handler (basing on xmlname) in the Handler Factory
-template class HandlerFactory::Register< GenericAsk< cbFailcheck > >;
+template class HandlerFactory::Register<GenericAsk<cbFailcheck> >;

--- a/src/Handlers/cbSaveBinary.cpp
+++ b/src/Handlers/cbSaveBinary.cpp
@@ -2,36 +2,30 @@
 std::string cbSaveBinary::xmlname = "SaveBinary";
 #include "../HandlerFactory.h"
 
-int cbSaveBinary::Init () {
-		Callback::Init();
-		pugi::xml_attribute attr = node.attribute("file");
-		if (!attr) {
-			attr = node.attribute("filename");
-			if (!attr) {
-				fn = solver->outIterFile("Save", "");
-			} else {
-                fn = attr.value();
-            }
-		} else {
-            fn = ((std::string) solver->outpath) + "_" + attr.value();
+int cbSaveBinary::Init() {
+    Callback::Init();
+    auto attr = node.attribute("file");
+    if (!attr) {
+        attr = node.attribute("filename");
+        if (!attr) {
+            fn = solver->outIterFile("Save", "");
+        } else {
+            fn = attr.value();
         }
-		return 0;
-	}
+    } else {
+        fn = solver->outpath + "_" + attr.value();
+    }
+    return 0;
+}
 
-
-int cbSaveBinary::DoIt () {
-		Callback::DoIt();
-		pugi::xml_attribute attr = node.attribute("comp");
-                const auto lattice = solver->getCartLattice();
-		if (attr) {
-			lattice->saveComp(fn, attr.value());
-		} else {
-			lattice->saveSolution(fn);
-            	//error("Missing comp attribute in SaveBinary");
-		}
-		return 0;
-	};
-
+int cbSaveBinary::DoIt() {
+    Callback::DoIt();
+    const auto attr = node.attribute("comp");
+    if (attr) solver->lattice->saveComp(fn, attr.value());
+    else
+        solver->lattice->saveSolution(fn);
+    return EXIT_SUCCESS;
+};
 
 // Register the handler (basing on xmlname) in the Handler Factory
-template class HandlerFactory::Register< GenericAsk< cbSaveBinary > >;
+template class HandlerFactory::Register<GenericAsk<cbSaveBinary> >;

--- a/src/Handlers/cbSaveCheckpoint.cpp
+++ b/src/Handlers/cbSaveCheckpoint.cpp
@@ -2,9 +2,9 @@
 std::string cbSaveCheckpoint::xmlname = "SaveCheckpoint";
 #include "../HandlerFactory.h"
 
-int cbSaveCheckpoint::Init () {
-		Callback::Init();
-		/*
+int cbSaveCheckpoint::Init() {
+    Callback::Init();
+    /*
 			Initialisation of handler checks for keep attribute 
 			inside of SaveCheckpoint. Keep attribute can be used
 			to save the last "x" number of checkpoints, or specify
@@ -12,92 +12,86 @@ int cbSaveCheckpoint::Init () {
 			DEFAULT behaviour is to return only the most recent 
 			checkpoint.
 		*/
-		pugi::xml_attribute attr = node.attribute("keep");
-		if (attr) {
-			if (std::string(attr.value()) == "all"){
-				// Look for the keyword all and use keep = 0 as flag to store all
-				keep = 0;
-			} else {
-				// If the attr value is not the string all, assume it is an int
-				keep = attr.as_int();
-				if ( keep < 0) {
-					// Check the user hasn't set keep to a negative value
-					error("Keeping a negative no. of chckpnts not allowed, returning default behaviour.");
-					keep = 1;
-				}
-			}
-		} else{
-			keep = 1;
-		}
+    pugi::xml_attribute attr = node.attribute("keep");
+    if (attr) {
+        if (std::string(attr.value()) == "all") {
+            // Look for the keyword all and use keep = 0 as flag to store all
+            keep = 0;
+        } else {
+            // If the attr value is not the string all, assume it is an int
+            keep = attr.as_int();
+            if (keep < 0) {
+                // Check the user hasn't set keep to a negative value
+                error("Keeping a negative no. of chckpnts not allowed, returning default behaviour.");
+                keep = 1;
+            }
+        }
+    } else {
+        keep = 1;
+    }
 
-		return 0;
-	}
+    return 0;
+}
 
-
-int cbSaveCheckpoint::DoIt () {
-		Callback::DoIt();
-		/*
+int cbSaveCheckpoint::DoIt() {
+    Callback::DoIt();
+    /*
 			Here we saveSolution to a _x.pri file where x is the MPI rank.
 			If keep == 0, then we save all solutions. Otherwise, we check
 			the size of the queue; less than keep then save file, else
 			delete the first set into the queue
 		*/
-		output("writing checkpoint");
-                const auto lattice = solver->getCartLattice();
-		const auto filename = solver->outIterCollectiveFile("checkpoint", "");
-		const auto restartFile = solver->outIterCollectiveFile("restart", ".xml");
-		auto fileStr = lattice->saveSolution(filename);
-                std::string restStr;
-		if (D_MPI_RANK == 0 ) {
-			writeRestartFile(filename.c_str(), restartFile.c_str());
-			restStr = restartFile;
-		}
-		if (keep != 0){
-			myqueue.push( fileStr );
-			myqueue_rst.push( restStr );
-			if (myqueue.size() > (size_t) keep) {
-				// myqueue should only ever reach the size of keep
-				fileStr = myqueue.front();
-				int rm_result = remove( fileStr.c_str() ); //Takes char
-				if (rm_result != 0) error("Checkpoint file was not deleted: %s",fileStr.c_str());
-				myqueue.pop();
+    output("writing checkpoint");
+    const auto filename = solver->outIterCollectiveFile("checkpoint", "");
+    const auto restartFile = solver->outIterCollectiveFile("restart", ".xml");
+    auto fileStr = solver->lattice->saveSolution(filename);
+    std::string restStr;
+    if (D_MPI_RANK == 0) {
+        writeRestartFile(filename.c_str(), restartFile.c_str());
+        restStr = restartFile;
+    }
+    if (keep != 0) {
+        myqueue.push(fileStr);
+        myqueue_rst.push(restStr);
+        if (myqueue.size() > (size_t)keep) {
+            // myqueue should only ever reach the size of keep
+            fileStr = myqueue.front();
+            int rm_result = remove(fileStr.c_str());  //Takes char
+            if (rm_result != 0) error("Checkpoint file was not deleted: %s", fileStr.c_str());
+            myqueue.pop();
 
-				if (D_MPI_RANK == 0 ) {
-					restStr = myqueue_rst.front();
-					rm_result = remove( restStr.c_str() );
-					if (rm_result != 0) error("Restart file was not deleted: %s",restStr.c_str());
-					myqueue_rst.pop();
-				}
-			}
-		}
+            if (D_MPI_RANK == 0) {
+                restStr = myqueue_rst.front();
+                rm_result = remove(restStr.c_str());
+                if (rm_result != 0) error("Restart file was not deleted: %s", restStr.c_str());
+                myqueue_rst.pop();
+            }
+        }
+    }
 
-		return 0;
-	};
+    return 0;
+};
 
-int cbSaveCheckpoint::writeRestartFile( const char * fn, const char * rf ) {
+int cbSaveCheckpoint::writeRestartFile(const char* fn, const char* rf) {
+    pugi::xml_document restartfile;
+    for (pugi::xml_node n = solver->configfile.first_child(); n; n = n.next_sibling()) { restartfile.append_copy(n); }
 
-		pugi::xml_document restartfile;
-		for (pugi::xml_node n = solver->configfile.first_child(); n; n = n.next_sibling()){
-			restartfile.append_copy(n);
-		}
+    pugi::xml_node n1 = restartfile.child("CLBConfig").child("LoadBinary");
+    if (!n1) {
+        // If it doesn't exist, create it before solve
+        n1 = restartfile.child("CLBConfig").child("Solve");
+        pugi::xml_node n2 = restartfile.child("CLBConfig").insert_child_before("LoadBinary", n1);
+        n2.append_attribute("file").set_value(fn);
+    } else {
+        // If it does exist, remove it and replace it with up to date file string
+        n1.remove_attribute(n1.attribute("file"));
+        n1.append_attribute("file").set_value(fn);
+    }
 
-		pugi::xml_node n1 = restartfile.child("CLBConfig").child("LoadBinary");
-		if (!n1){
-			// If it doesn't exist, create it before solve
-			n1 = restartfile.child("CLBConfig").child("Solve");
-			pugi::xml_node n2 = restartfile.child("CLBConfig").insert_child_before("LoadBinary", n1);
-			n2.append_attribute("file").set_value(fn);
-		} else {
-			// If it does exist, remove it and replace it with up to date file string
-			n1.remove_attribute(n1.attribute("file"));
-			n1.append_attribute("file").set_value(fn);	
-		}
+    restartfile.save_file(rf);
 
-		restartfile.save_file( rf );
-
-	
-	return 0;
+    return 0;
 }
 
 // Register the handler (basing on xmlname) in the Handler Factory
-template class HandlerFactory::Register< GenericAsk< cbSaveCheckpoint > >;
+template class HandlerFactory::Register<GenericAsk<cbSaveCheckpoint> >;

--- a/src/Handlers/cbSaveMemoryDump.cpp
+++ b/src/Handlers/cbSaveMemoryDump.cpp
@@ -2,33 +2,28 @@
 std::string cbSaveMemoryDump::xmlname = "SaveMemoryDump";
 #include "../HandlerFactory.h"
 
-int cbSaveMemoryDump::Init () {
-		Callback::Init();
-		pugi::xml_attribute attr = node.attribute("file");
-		if (!attr) {
-			attr = node.attribute("filename");
-			if (!attr) {
-				fn = solver->outIterFile("Save", "");
-			} else {
-                fn = attr.value();
-            }
-		} else {
-            fn = solver->outpath + "_" + attr.value();
+int cbSaveMemoryDump::Init() {
+    Callback::Init();
+    pugi::xml_attribute attr = node.attribute("file");
+    if (!attr) {
+        attr = node.attribute("filename");
+        if (!attr) {
+            fn = solver->outIterFile("Save", "");
+        } else {
+            fn = attr.value();
         }
-		return 0;
-	}
+    } else {
+        fn = solver->outpath + "_" + attr.value();
+    }
+    return 0;
+}
 
-
-int cbSaveMemoryDump::DoIt () {
-		Callback::DoIt();
-		pugi::xml_attribute attr= node.attribute("comp");
-		if (attr) {
-            error("Depreceted API call. Use SaveBinary with comp parameter");
-        }
-		solver->getCartLattice()->saveSolution(fn);
-		return 0;
-	};
-
+int cbSaveMemoryDump::DoIt() {
+    Callback::DoIt();
+    if (node.attribute("comp")) error("Deprecated API call. Use SaveBinary with comp parameter");
+    solver->lattice->saveSolution(fn);
+    return 0;
+};
 
 // Register the handler (basing on xmlname) in the Handler Factory
-template class HandlerFactory::Register< GenericAsk< cbSaveMemoryDump > >;
+template class HandlerFactory::Register<GenericAsk<cbSaveMemoryDump> >;

--- a/src/Handlers/cbTXT.cpp
+++ b/src/Handlers/cbTXT.cpp
@@ -3,33 +3,22 @@ std::string cbTXT::xmlname = "TXT";
 #include "../HandlerFactory.h"
 #include "../vtkLattice.h"
 
-int cbTXT::Init () {
-		Callback::Init();
-		pugi::xml_attribute attr = node.attribute("name");
-		nm = "TXT";
-		if (attr) nm = attr.value();
-		attr = node.attribute("what");
-		if (attr) {
-		        s.add_from_string(attr.value(),',');
-                } else {
-                        s.add_from_string("all",',');
-                }
-		gzip = false;
-		attr = node.attribute("gzip");
-		if (attr) gzip = attr.as_bool();
-		txt_type = 0;
-		if (gzip) txt_type = 1;
-		return 0;
-	}
+int cbTXT::Init() {
+    Callback::Init();
+    auto attr = node.attribute("name");
+    nm = attr ? attr.value() : "TXT";
+    attr = node.attribute("what");
+    s.add_from_string(attr ? attr.value() : "all", ',');
+    gzip = node.attribute("gzip").as_bool();
+    txt_type = gzip ? 1 : 0;
+    return EXIT_SUCCESS;
+}
 
-
-int cbTXT::DoIt () {
-		Callback::DoIt();
-                const auto filename = solver->outIterFile(nm, "");
-                auto& lattice = *solver->getCartLattice();
-                return txtWriteLattice(filename.c_str(), lattice, solver->units, s, txt_type);
-	};
-
+int cbTXT::DoIt() {
+    Callback::DoIt();
+    const auto filename = solver->outIterFile(nm, "");
+    return std::visit([&](const auto lattice_ptr) { return txtWriteLattice(filename, *lattice_ptr, solver->units, s, txt_type); }, solver->getLatticeVariant());
+};
 
 // Register the handler (basing on xmlname) in the Handler Factory
-template class HandlerFactory::Register< GenericAsk< cbTXT > >;
+template class HandlerFactory::Register<GenericAsk<cbTXT> >;

--- a/src/Lists.h.Rt
+++ b/src/Lists.h.Rt
@@ -283,6 +283,14 @@ class Model_m : public Model {
 public:
     Model_m();
 
+    // Lookup density index by name
+    static int lookupFieldIndexByName(const std::string& name) { <?R
+for (f in rows(Fields)) { ?>
+        if (name == "<?%s f$name ?>") return <?%s f$Index?>; <?R
+} ?>
+        return -1;
+    }
+
     // Offset directions (Q) stored as constexpr array of int triplets; for compile-time computations requiring Q
     static constexpr auto offset_directions = model_details::makeOffsetDirections();                           /// Array of offset directions
     static constexpr size_t Q  = offset_directions.size();                                                     /// Number of offset directions

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -194,11 +194,9 @@ AC_ARG_WITH([cpp-flags],
 		[privide additionals flags for the compiler]),
 	[CONF_CPPFLAGS="$withval"])		
 
-NVFLAGS=""
-
 if test "x${COMPILER_BINDIR}" != "x"
 then
-	NVFLAGS="-ccbin=${COMPILER_BINDIR} "
+	NVFLAGS="${NVFLAGS} -ccbin=${COMPILER_BINDIR} "
 fi
 
 if test -z "$CXX"

--- a/src/vtkLattice.h
+++ b/src/vtkLattice.h
@@ -16,6 +16,7 @@ int vtuWriteLattice(const std::string& filename, ArbLattice& lattice, const Unit
 int binWriteLattice(const std::string& filename, CartLattice& lattice, const UnitEnv& units);
 int binWriteLattice(const std::string& filename, ArbLattice& lattice, const UnitEnv& units);
 int txtWriteLattice(const std::string& filename, CartLattice& lattice, const UnitEnv&, const name_set& s, int type);
+int txtWriteLattice(const std::string& filename, ArbLattice& lattice, const UnitEnv&, const name_set& s, int type);
 void screenDumpLattice(const CartLattice& lattice);
 int initMean(const std::string& filename);
 int writeMean(const std::string& filename, const CartLattice& lattice, int, int iter, double);

--- a/src/vtkLattice.h
+++ b/src/vtkLattice.h
@@ -14,6 +14,7 @@
 int vtkWriteLattice(const std::string& filename, CartLattice& lattice, const UnitEnv&, const name_set& s, const lbRegion& region);
 int vtuWriteLattice(const std::string& filename, ArbLattice& lattice, const UnitEnv&, const name_set& s);
 int binWriteLattice(const std::string& filename, CartLattice& lattice, const UnitEnv& units);
+int binWriteLattice(const std::string& filename, ArbLattice& lattice, const UnitEnv& units);
 int txtWriteLattice(const std::string& filename, CartLattice& lattice, const UnitEnv&, const name_set& s, int type);
 void screenDumpLattice(const CartLattice& lattice);
 int initMean(const std::string& filename);


### PR DESCRIPTION
***Some updates to the arbitrary grid formulation:***

- Edges between bulk nodes removed from the connectivity graph. This reduces the communication volume and associated costs.
- The local permutation strategy can now be set via the (optional) "permutation" attribute of the "ArbitraryLattice" xml node. Valid values are:
  - "none" - use default ordering, not recommended, only for debugging/benchmarking purposes
  - "coords" - sort only by coordinates, this was the previous behavior. This is still the default.
  - "type" - sort only by node type, not recommended, only for debugging/benchmarking purposes
  - "both" - sort by node type, subsort by coordinates. Somewhat surprisingly, for the fontaine benchmark (on a single GPU), this resulted in a ~8.5% performance penalty, meaning less coalesced memory access outweighed the gains from more efficient warp utilization. I still think for some cases this might be more efficient than the "coords" strategy (maybe for very low porosity, or when the geometry is more structured?)
- Added some missing handlers

***Outstanding items:***

- Symmetry conditions
- Some handlers are still missing
  - Mostly related to things like particles, so implementing them is outside the scope of this project
  - RunR is definitely still broken
  - Failcheck semantics make little sense for arbitrary grid, see #476
  - You can check which handlers still need implementing by grepping for `getCartLattice`
- Adjoint functionality is definitely broken, the main iteration is missing as well as saving/loading components. There are probably also a bunch of other places where I screwed something up, but I don't really have the bandwidth to go hunting for them.