### PR TITLE
Add fixes for building on macOS

### DIFF
--- a/src/makefile.main.Rt
+++ b/src/makefile.main.Rt
@@ -287,7 +287,7 @@ wiki/schema/<?%s m ?>.xsd:$(SRC)/schema.xsd.Rt $(SRC)/conf.R <?%s d ?>/<?%s m ?>
 %_sp.c:%.c
 	@echo "  SP-CONST   $@"
 	@$(MKPATH) $@
-	@cat $< | sed -r 's/([^a-zA-Z0-9][0-9]+\.[0-9]*([eE][-+]?[0-9]+)?)[fL]+/\1f/g' > $@
+	@cat $< | sed -E 's/([^a-zA-Z0-9][0-9]+\.[0-9]*([eE][-+]?[0-9]+)?)[fL]+/\1f/g' > $@
 
 
 

--- a/src/models.R
+++ b/src/models.R
@@ -19,7 +19,7 @@ get.model.names = function(path) {
 
 get.models = function() {
 	M1 = get.model.dirs("git ls-files | grep 'conf.mk$'")
-	M2 = get.model.dirs("find models/ -name 'conf.mk'")
+	M2 = get.model.dirs("find models -name 'conf.mk'")
 	M3 = union(M1,M2)
 	Models = do.call(rbind, lapply(M3,function (m) {
 		ret = get.model.names(m)

--- a/tools/dep.R
+++ b/tools/dep.R
@@ -9,7 +9,7 @@ opt <- parse_args(OptionParser(usage="Usage: ADmod -f inputfile [-o outputfile]"
 if (opt$path != "") setwd(opt$path)
 
 # 'grep' all the includes
-f = pipe("grep '# *include' `find -regex '.*[.]\\(c\\|cu\\|cpp\\|h\\|hpp\\)'` | sed -n 's/^\\([^:]*\\):[ \\t]*#[ \\t]*include[ \\t]*[\"<]\\(.*\\)[>\"]/\\1,\\2/gp'")
+f = pipe("grep '# *include' `find . -type f \\( -name '*.c' -o -name '*.cu' -o -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \\)` | sed -n -e 's/^\\([^:]*\\):[ \\t]*#include[ \\t]*[\"<]\\(.*\\)[>\"]/\\1,\\2/gp'")
 w = read.csv(f,col.names=c("file","dep"), stringsAsFactor=F, header=FALSE);
 
 # make the relative paths in include statement relative to *here*


### PR DESCRIPTION
- `-E` in sed to be POSIX compliant
- Remove regex in `find` to make it more tolerable and portable
- `find models/` produces extra slashes in results on macos ( i.e. `models//multiphase/`) but not on Linux. `find models` does not give extra slashes and behaves the same as `find models/` on models

Tested on my M2 Macbook Air, all the clusters where I use TCLB, and my workstation. 

@TravisMitchell  FYI 

I will also CI at some point, but not in this PR. 