### PR TITLE
Correcting the size calculation in allocation of CartLattice's FTabs

### DIFF
--- a/src/CartLattice.cpp.Rt
+++ b/src/CartLattice.cpp.Rt
@@ -747,7 +747,7 @@ void CartLattice::updateAllSamples(){
 void FTabs::PreAlloc(int nx,int ny,int nz) {
   size_t size;
 <?R for (m in NonEmptyMargin) { ?>
-  size = <?R C(m$Size,float=F) ?>*sizeof(storage_t);
+  size = (size_t) <?R C(m$Size,float=F) ?>*sizeof(storage_t);
   CudaPreAlloc( (void**)&<?%s m$name ?>, size );
 <?R } ?>
 }

--- a/src/cross.cu
+++ b/src/cross.cu
@@ -49,7 +49,7 @@ CudaError HandleError( CudaError err,
         std::vector< std::pair< void *, std::vector< ptrpair > > > freelist;
 
         CudaError cudaPreAlloc(void ** ptr, size_t size) {
-                debug1("Preallocation of %d b\n", (int) size);
+                debug1("Preallocation of %lu b\n", size);
                 ptrlist.push_back(ptrpair(ptr, size));
         //	return cudaMalloc(ptr, size);
                 return CudaSuccess;
@@ -71,13 +71,13 @@ CudaError HandleError( CudaError err,
                 }
                 char * tmp = NULL;
                 if (fullsize > 1e9) {
-                        NOTICE("[%d] Cumulative allocation of %d b (%.1f GB)\n", D_MPI_RANK, (int) fullsize, ((float) fullsize)/1e9);
+                        NOTICE("[%d] Cumulative allocation of %lu b (%.1f GB)\n", D_MPI_RANK, fullsize, ((float) fullsize)/1e9f);
                 } else if (fullsize > 1e6) {
-                        NOTICE("[%d] Cumulative allocation of %d b (%.1f MB)\n", D_MPI_RANK, (int) fullsize, ((float) fullsize)/1e6);
+                        NOTICE("[%d] Cumulative allocation of %lu b (%.1f MB)\n", D_MPI_RANK, fullsize, ((float) fullsize)/1e6f);
                 } else if (fullsize > 1e3) {
-                        NOTICE("[%d] Cumulative allocation of %d b (%.1f kB)\n", D_MPI_RANK, (int) fullsize, ((float) fullsize)/1e3);
+                        NOTICE("[%d] Cumulative allocation of %lu b (%.1f kB)\n", D_MPI_RANK, fullsize, ((float) fullsize)/1e3f);
                 } else {
-                        NOTICE("[%d] Cumulative allocation of %d b\n", D_MPI_RANK, (int) fullsize);
+                        NOTICE("[%d] Cumulative allocation of %lu b\n", D_MPI_RANK, fullsize);
                 }
                 CudaMalloc((void **) &tmp,fullsize);
                 if (tmp == NULL) {


### PR DESCRIPTION
If one want to calculate (potentially) huge product of int-s, you should do:
```c++
int nx,ny,nz;
size_t n = (size_t) nx*ny*nz;
```
which is equivalent to:
```c++
size_t n = ((((size_t) nx)*ny)*nz);
```
which is different than:
```c++
size_t n = (size_t) (nx*ny*nz);
```
which first multiplied (overflows) and then converts.

Fixes #496 