### PR TITLE
Fixing the globals in RunR

### DIFF
--- a/src/Handlers/acSolve.cpp
+++ b/src/Handlers/acSolve.cpp
@@ -7,7 +7,8 @@ int acSolve::Init () {
 		if (GenericAction::ExecuteInternal()) return -1;
 		int stop=0;
 		do {
-			int next_it = Next(solver->iter);
+			int my_next_it = Next(solver->iter);
+			int next_it = my_next_it;
 			for (size_t i=0; i<solver->hands.size(); i++) {
 				int it  = solver->hands[i].Next(solver->iter);
 				if ((it > 0) && (it < next_it)) next_it = it;
@@ -15,7 +16,9 @@ int acSolve::Init () {
 			solver->steps = next_it;
 			MPI_Bcast(&solver->steps, 1, MPI_INT, 0, MPMD.local);
 			solver->iter += solver->steps;
-			solver->lattice->Iterate(solver->steps, solver->iter_type);
+			int iter_type = solver->iter_type;
+			if (solver->steps == my_next_it) iter_type |= ITER_LASTGLOB;
+			solver->lattice->Iterate(solver->steps, iter_type);
 			CudaDeviceSynchronize();
 			MPI_Barrier(MPMD.local);
 			for (size_t i=0; i<solver->hands.size(); i++) {

--- a/src/Handlers/cbRunR.cpp
+++ b/src/Handlers/cbRunR.cpp
@@ -796,6 +796,8 @@ int cbRunR::Init() {
 		output("%s\n",source.c_str());
 		output("--------------------------------\n");
 	}
+	old_iter_type = solver->iter_type;
+	solver->iter_type |= ITER_LASTGLOB;
 	return 0;
 }
 
@@ -840,6 +842,11 @@ int cbRunR::DoIt() {
 		return -1;
 	}
 	return 0;
+}
+
+int cbRunR::Finish () {
+	solver->iter_type = old_iter_type;
+	return Callback::Finish();
 }
 
 

--- a/src/Handlers/cbRunR.h
+++ b/src/Handlers/cbRunR.h
@@ -29,9 +29,11 @@ class cbRunR : public  Callback  {
     bool python;
     static int s_tag;
     int tag;
+    int old_iter_type;
 public:
     int Init ();
     int DoIt ();
+    int Finish ();
 };
 
 #endif // WITH_R


### PR DESCRIPTION
Adding `ITER_LASTGLOB` to RunR element, and to the last iteration of Solve action.

@shkodm, could you test this?