### PR TITLE
Introducing `autosym2`

### DIFF
--- a/src/LatticeAccess.inc.cpp.Rt
+++ b/src/LatticeAccess.inc.cpp.Rt
@@ -34,6 +34,10 @@
   #define real_to_storage_shift(x__,y__) real_to_storage(x__)
 #endif
 
+#ifndef NODE_SYMZ
+  #define NODE_SYMZ 0
+#endif
+
 /// Get only type of node
 CudaDeviceFunction flag_t LatticeContainer::getType(int x, int y, int z) const
 {
@@ -417,8 +421,10 @@ public:
     
     si = which(Fields$name == fn)
     sf = rows(Fields)[[si]]
-    sd = d
-    sd[i] = sd[i]*(-1)
+    sd_plus = d
+    sd_plus[i] = autosym_shift-sd_plus[i]
+    sd_minus = d
+    sd_minus[i] = -autosym_shift-sd_minus[i]
 ?>
 template < class PARENT >
 template <class dx_t, class dy_t, class dz_t>
@@ -426,12 +432,12 @@ CudaDeviceFunction real_t SymmetryAccess< PARENT >::<?%s paste0(this_fun, f$nice
 {
   <?R if (paste0("SYM",ch[i]) %in% NodeTypes$group) { ?>
   if (<?R C(d[i]) ?> > range_int<0>()) {
-    if ((this->getNodeType() & NODE_SYM<?%s ch[i] ?>) == NODE_Symmetry<?%s ch[i] ?>_plus) {
-      return <?%s paste0(sig, next_fun, sf$nicename) ?>(<?R C(sd,sep=", ") ?>);
+    if ((this->getNodeType() & NODE_SYM<?%s ch[i] ?>) == NODE_<?%s autosym_name ?><?%s ch[i] ?>_plus) {
+      return <?%s paste0(sig, next_fun, sf$nicename) ?>(<?R C(sd_plus,sep=", ",float=FALSE,wrap.const=range_int) ?>);
     }
   } else if (<?R C(d[i]) ?> < range_int<0>()) {
-    if ((this->getNodeType() & NODE_SYM<?%s ch[i] ?>) == NODE_Symmetry<?%s ch[i] ?>_minus) {
-      return <?%s paste0(sig, next_fun, sf$nicename) ?>(<?R C(sd,sep=", ") ?>);
+    if ((this->getNodeType() & NODE_SYM<?%s ch[i] ?>) == NODE_<?%s autosym_name ?><?%s ch[i] ?>_minus) {
+      return <?%s paste0(sig, next_fun, sf$nicename) ?>(<?R C(sd_minus,sep=", ",float=FALSE,wrap.const=range_int) ?>);
     }
   }
   <?R } ?>
@@ -444,9 +450,27 @@ CudaDeviceFunction real_t SymmetryAccess< PARENT >::<?%s paste0(this_fun, f$nice
 template < class PARENT >
 template <class N>
 CudaDeviceFunction void SymmetryAccess< PARENT >::pop<?%s s$suffix ?>(N & node) const
-{
-  parent::pop<?%s s$suffix ?>(node);
-  <?R resolve.symmetries(Density[s$load.densities,,drop=FALSE]) ?>
+{ <?R
+    if (Options$autosym == 0) { ?>
+      parent::pop<?%s s$suffix ?>(node); <?R
+    } else if (Options$autosym == 1) { ?>
+      parent::pop<?%s s$suffix ?>(node); <?R
+      resolve.symmetries(Density[s$load.densities,,drop=FALSE])
+    } else if (Options$autosym == 2) { ?>
+      if (this->getNodeType() & (NODE_SYMX | NODE_SYMY | NODE_SYMZ)) { <?R
+        dens = Density;
+        dens$load = s$load.densities;
+        for (d in rows(dens)) if (d$load) {
+          f = rows(Fields)[[match(d$field, Fields$name)]]
+          dp = c(-d$dx, -d$dy, -d$dz) ?>
+          <?%s paste("node",d$name,sep=".") ?> = load_<?%s f$nicename ?>(range_int< <?%d dp[1] ?> >(),range_int< <?%d dp[2] ?> >(),range_int< <?%d dp[3] ?> >()); <?R
+        } else if (!is.na(d$default)) { ?>
+          <?%s paste("node",d$name,sep=".") ?> = <?%f d$default ?>; <?R
+        } ?>
+      } else {
+        parent::pop<?%s s$suffix ?>(node);
+      } <?R
+    } else stop("Unknown autosym option") ?>
 }
 <?R } } ?>
 

--- a/src/conf.R
+++ b/src/conf.R
@@ -33,7 +33,7 @@ if (! SYMALGEBRA) {
 	library(symAlgebra,quietly=TRUE,warn.conflicts=FALSE)
 }
 
-if (is.null(Options$autosym)) Options$autosym = FALSE
+if (is.null(Options$autosym)) Options$autosym = 0
 
 #source("linemark.R")
 
@@ -370,7 +370,7 @@ if (is.null(Description)) {
 }
 
 
-if (Options$autosym) { ## Automatic symmetries
+if (Options$autosym > 0) { ## Automatic symmetries
   symmetries = data.frame(symX=c(-1,1,1),symY=c(1,-1,1),symZ=c(1,1,-1))
 
   for (g in unique(DensityAll$group)) {
@@ -397,6 +397,24 @@ if (Options$autosym) { ## Automatic symmetries
   for (s in names(symmetries)) {
     sel = Fields[,s] == ""
     Fields[sel,s] = Fields$name[sel]
+  }
+
+  rownames(Fields) = Fields$name	
+  ranges = c("minx","maxx","miny","maxy","minz","maxz")
+  
+  tmp = -1234
+  while (any(Fields[,ranges] != tmp)) {
+	tmp = Fields[,ranges]
+	for (f in rownames(Fields)) {
+		r = Fields[f,ranges]
+		for (s in names(symmetries)) {
+			nf = Fields[f,s]
+			or = Fields[nf,ranges]
+			nr = r * rep(symmetries[,s],each=2)
+			cr = c(range(or[1:2],nr[1:2]),range(or[1:2+2],nr[1:2+2]),range(or[1:2+4],nr[1:2+4]))
+			Fields[nf,ranges] = cr
+		}
+	}
   }
 
   AddNodeType("SymmetryX_plus",  group="SYMX")

--- a/src/conf.R
+++ b/src/conf.R
@@ -400,32 +400,59 @@ if (Options$autosym > 0) { ## Automatic symmetries
   }
 
   rownames(Fields) = Fields$name	
-  ranges = c("minx","maxx","miny","maxy","minz","maxz")
   
-  tmp = -1234
-  while (any(Fields[,ranges] != tmp)) {
-	tmp = Fields[,ranges]
-	for (f in rownames(Fields)) {
-		r = Fields[f,ranges]
-		for (s in names(symmetries)) {
-			nf = Fields[f,s]
-			or = Fields[nf,ranges]
-			nr = r * rep(symmetries[,s],each=2)
-			cr = c(range(or[1:2],nr[1:2]),range(or[1:2+2],nr[1:2+2]),range(or[1:2+4],nr[1:2+4]))
-			Fields[nf,ranges] = cr
+  if (Options$autosym == 1) {
+	autosym_shift = 0
+	autosym_name = "Symmetry"
+  } else if (Options$autosym == 2) {
+	autosym_shift = 1
+	autosym_name = "SymmetryEdge"
+  } else stop("unknown autosym value")
+
+  directions = lapply(rows(Fields), function(f)	expand.grid(dx=f$minx:f$maxx,dy=f$miny:f$maxy,dz=f$minz:f$maxz))
+  names(directions) = Fields$name
+  dir.sort = function(d) {
+	d = unique(d)
+	d[order(d[,3],d[,2],d[,1]),]
+  }
+  directions = lapply(directions,dir.sort)
+  tmp = NULL
+  while (!identical(directions, tmp)) {
+	tmp = directions
+	for (f in rows(Fields)) {
+		d = directions[[f$name]]
+		for (i in 1:3) {
+			nfn = f[[names(symmetries)[i]]]
+			od = directions[[nfn]]
+			cr = od
+			nd = d[d[,i] < 0,, drop=FALSE]
+			nd[,i] = -nd[,i] - autosym_shift
+			cr = rbind(cr,nd)
+			nd = d[d[,i] > 0,, drop=FALSE]
+			nd[,i] = -nd[,i] + autosym_shift
+			cr = rbind(cr,nd)
+			directions[[nfn]] = cr
 		}
 	}
+	directions = lapply(directions,dir.sort)
   }
+  Fields$minx = sapply(directions, function(x) min(x$dx))
+  Fields$maxx = sapply(directions, function(x) max(x$dx))
+  Fields$miny = sapply(directions, function(x) min(x$dy))
+  Fields$maxy = sapply(directions, function(x) max(x$dy))
+  Fields$minz = sapply(directions, function(x) min(x$dz))
+  Fields$maxz = sapply(directions, function(x) max(x$dz))
 
-  AddNodeType("SymmetryX_plus",  group="SYMX")
-  AddNodeType("SymmetryX_minus", group="SYMX")
-  AddNodeType("SymmetryY_plus",  group="SYMY")
-  AddNodeType("SymmetryY_minus", group="SYMY")
+  
+  AddNodeType(paste0(autosym_name, "X_plus"),   group="SYMX")
+  AddNodeType(paste0(autosym_name, "X_minus"),  group="SYMX")
+  AddNodeType(paste0(autosym_name, "Y_plus"),   group="SYMY")
+  AddNodeType(paste0(autosym_name, "Y_minus"),  group="SYMY")
   if (all(range(Fields$minz,Fields$maxz) == c(0,0))) {
 	# we're in 2D
   } else {
-	AddNodeType("SymmetryZ_plus",  group="SYMZ")
-	AddNodeType("SymmetryZ_minus", group="SYMZ")
+	AddNodeType(paste0(autosym_name, "Z_plus"),   group="SYMZ")
+	AddNodeType(paste0(autosym_name, "Z_minus"),  group="SYMZ")
   }
 }
 

--- a/src/makefile.main.Rt
+++ b/src/makefile.main.Rt
@@ -154,7 +154,7 @@ for (d in destinations) {
 				paste0("  ",
 					names(opts),
 					" = ",
-					ifelse(opts==0,"FALSE","TRUE"),
+					opts,
 					ifelse(seq_along(opts) != length(opts),",","")
 				)
 			)

--- a/src/models.R
+++ b/src/models.R
@@ -47,11 +47,23 @@ get.models = function() {
 			opts_terms = terms(opts)
 			opts = attr(opts_terms,"factors")
 			opts = data.frame(t(opts))
-			rownames(opts) = paste(name,gsub(":","_",rownames(opts)),sep="_")
+			opts[] = opts > 0
 			if (attr(opts_terms, "intercept") == 1) {
-				opts[name,]=0
+				opts = rbind(opts, FALSE)
 			}
-#			opts = apply(opts, 2, function(x) x > 0)
+			if ("autosym" %in% names(opts)) {
+				opts$autosym = ifelse(opts$autosym, 1, 0)
+				x = opts[opts$autosym > 0,,drop=FALSE]
+				x$autosym = 2
+				opts = rbind(opts, x)
+			}
+			rownames(opts) = sapply(seq_len(nrow(opts)), function(i) {
+				x = opts[i,]
+				w = names(opts)
+				w = paste0(w, ifelse(x>1,x,""))
+				w = c(name, w[x>0])
+				paste(w,collapse="_")
+			})
 		} else {
 			opts = data.frame(row.names=name)
 		}


### PR DESCRIPTION
This PR introduces and alternative version of the `autosym` capability. All models with the `autosym` option can now be compiled with `autosym2` option, which introduces `SymmetryEdge` boundary conditions, which are symmetry boundary conditions, but not on the middle of element, but on the edge of the element. This allows for using symmetry in common cases with even number of elements. Eg. for a simulation of a droplet, with `autosym` we need 99x99 cross-section, and the center of the droplet at 49.5, with the reduced domain to 50x50 with symmetry, and with `autosym2` one can use a channel of 100x100 and the particle can be centrally between elements at 50.