### PR TITLE
Fixes to  RunR for the arbitrary grid

### DIFF
--- a/src/ArbLattice.cpp
+++ b/src/ArbLattice.cpp
@@ -517,13 +517,41 @@ void ArbLattice::SetFirstTabs(int tab_in, int tab_out) {
 }
 
 
+std::vector<big_flag_t> ArbLattice::getFlags() const {
+    size_t size = getLocalSize();
+    std::vector<big_flag_t> ret(size);
+    CudaMemcpy(ret.data(), launcher.container.node_types, sizeof(big_flag_t)*getLocalSize(), CudaMemcpyDeviceToHost);
+    return ret;
+}
 
+std::vector<real_t> ArbLattice::getField(const Model::Field& f) {
+	assert(f.isParameter);
+    storage_t* from = getSnapPtr(Snap);
+	assert(sizeof(storage_t) == sizeof(real_t));
+    size_t size = getLocalSize();
+    std::vector<real_t> ret(size);
+	debug2("Pulling all %s\n",f.name.c_str());
+    CudaMemcpy(ret.data(), &from[f.id*sizes.snaps_pitch], size*sizeof(real_t),
+               CudaMemcpyDeviceToHost);
+    return ret;
+}
 
-std::vector<big_flag_t> ArbLattice::getFlags() const { throw std::runtime_error{"UNIMPLEMENTED"}; return {}; };
-std::vector<real_t> ArbLattice::getField(const Model::Field& f) { throw std::runtime_error{"UNIMPLEMENTED"}; return {}; };
 std::vector<real_t> ArbLattice::getFieldAdj(const Model::Field& f) { throw std::runtime_error{"UNIMPLEMENTED"}; return {}; };
-void ArbLattice::setFlags(const std::vector<big_flag_t>& x) { throw std::runtime_error{"UNIMPLEMENTED"}; return; };
-void ArbLattice::setField(const Model::Field& f, const std::vector<real_t>& x) { throw std::runtime_error{"UNIMPLEMENTED"}; return; };
+void ArbLattice::setFlags(const std::vector<big_flag_t>& x) { throw std::runtime_error{"NOT SUPPORTED FOR ARB LATTICE"}; return; };
+
+void ArbLattice::setField(const Model::Field& f, const std::vector<real_t>& x) {
+	assert(f.isParameter);
+	storage_t* from = getSnapPtr(Snap);
+	assert(sizeof(storage_t) == sizeof(real_t));
+    size_t size = getLocalSize();
+	debug2("Setting all %s\n", f.name.c_str());
+	CudaMemcpy(
+		&from[f.id*sizes.snaps_pitch],
+		x.data(),
+		size*sizeof(real_t),
+		CudaMemcpyHostToDevice);
+}
+
 void ArbLattice::setFieldAdjZero(const Model::Field& f) { throw std::runtime_error{"UNIMPLEMENTED"}; return; };
 
 

--- a/src/ArbLattice.cpp
+++ b/src/ArbLattice.cpp
@@ -537,7 +537,10 @@ std::vector<real_t> ArbLattice::getField(const Model::Field& f) {
 }
 
 std::vector<real_t> ArbLattice::getFieldAdj(const Model::Field& f) { throw std::runtime_error{"UNIMPLEMENTED"}; return {}; };
-void ArbLattice::setFlags(const std::vector<big_flag_t>& x) { throw std::runtime_error{"NOT SUPPORTED FOR ARB LATTICE"}; return; };
+void ArbLattice::setFlags(const std::vector<big_flag_t>& x) {
+    output("overwriting all flags\n");
+	CudaMemcpy(node_types_device.get(), x.data(), sizeof(big_flag_t)*getLocalSize(), CudaMemcpyHostToDevice);
+};
 
 void ArbLattice::setField(const Model::Field& f, const std::vector<real_t>& x) {
 	assert(f.isParameter);

--- a/src/Node.hpp.Rt
+++ b/src/Node.hpp.Rt
@@ -21,7 +21,7 @@
 	}
 	f = Fields
 	AddMacro(paste0_s(f$nicename,"(...)"), paste0_s("acc.template load_", f$nicename, "< __VA_ARGS__ >()"))
-	AddMacro(paste0_s(f$nicename,"_dyn(...)"), paste0_s("acc.template load_", f$nicename, "(__VA_ARGS__)"))
+	AddMacro(paste0_s(f$nicename,"_dyn(...)"), paste0_s("acc.load_", f$nicename, "(__VA_ARGS__)"))
 	XYZ = c("X","Y","Z")
 	AddMacro(XYZ, paste0_s("acc.get", XYZ,"()"))
 	AddMacro("NodeType", paste0_s("acc.getNodeType()"))


### PR DESCRIPTION
Mostly added getters and setters.

Also fixed a compilation error for the phase field, when compiling with >= c++17 .

Should be noted that for instance for scalar quantities, arbitrary grid returns 1D arrays with respect to the geometry,
whereas cartesian returns 3D arrays. For complex setup one can just use `Solver$GEOMETRY$BOUNDARY` and
`Solver$Geometry$X`(or `Y`, `Z`) arrays, instead of assuming certain mesh structure. 

Tested by:
- Running interactive RunR session for cartesian and arbitrary grid
- Initialising droplet inside a periodic domain using RunR 

